### PR TITLE
ENH: Minor changes to leap_seconds function

### DIFF
--- a/dgp/lib/time_utils.py
+++ b/dgp/lib/time_utils.py
@@ -1,10 +1,31 @@
-import datetime
+from datetime import datetime, timedelta
 import pandas as pd
 import collections
+from functools import lru_cache
+
+leap_second_table = [(datetime(1980, 1, 1), datetime(1981, 7, 1)),
+                     (datetime(1981, 7, 1), datetime(1982, 7, 1)),
+                     (datetime(1982, 7, 1), datetime(1983, 7, 1)),
+                     (datetime(1983, 7, 1), datetime(1985, 7, 1)),
+                     (datetime(1985, 7, 1), datetime(1988, 1, 1)),
+                     (datetime(1988, 1, 1), datetime(1990, 1, 1)),
+                     (datetime(1990, 1, 1), datetime(1991, 1, 1)),
+                     (datetime(1991, 1, 1), datetime(1992, 7, 1)),
+                     (datetime(1992, 7, 1), datetime(1993, 7, 1)),
+                     (datetime(1993, 7, 1), datetime(1994, 7, 1)),
+                     (datetime(1994, 7, 1), datetime(1996, 1, 1)),
+                     (datetime(1996, 1, 1), datetime(1997, 7, 1)),
+                     (datetime(1997, 7, 1), datetime(1999, 1, 1)),
+                     (datetime(1999, 1, 1), datetime(2006, 1, 1)),
+                     (datetime(2006, 1, 1), datetime(2009, 1, 1)),
+                     (datetime(2009, 1, 1), datetime(2012, 7, 1)),
+                     (datetime(2012, 7, 1), datetime(2015, 7, 1)),
+                     (datetime(2015, 7, 1), datetime(2017, 1, 1))]
+
 
 def datetime_to_sow(dt):
     def _to_sow(dt):
-        delta = dt - datetime.datetime(1980, 1, 6)
+        delta = dt - datetime(1980, 1, 6)
         week = delta.days // 7
         sow = (delta.days % 7) * 86400. + delta.seconds + delta.microseconds * 1e-6
         return week, sow
@@ -17,23 +38,39 @@ def datetime_to_sow(dt):
     else:
         return _to_sow(dt)
 
+
 def convert_gps_time(gpsweek, gpsweekseconds, format='unix'):
     """
-    convert_gps_time :: (String -> String) -> Float
+    Converts a GPS time format (weeks + seconds since 6 Jan 1980) to a UNIX
+    timestamp (seconds since 1 Jan 1970) without correcting for UTC leap
+    seconds.
 
-    Converts a GPS time format (weeks + seconds since 6 Jan 1980) to a UNIX timestamp
-    (seconds since 1 Jan 1970) without correcting for UTC leap seconds.
+    Static values gps_delta and gpsweek_cf are defined by the below functions
+    (optimization) gps_delta is the time difference (in seconds) between UNIX
+    time and GPS time.
 
-    Static values gps_delta and gpsweek_cf are defined by the below functions (optimization)
-    gps_delta is the time difference (in seconds) between UNIX time and GPS time.
     gps_delta = (dt.datetime(1980, 1, 6) - dt.datetime(1970, 1, 1)).total_seconds()
 
     gpsweek_cf is the coefficient to convert weeks to seconds
     gpsweek_cf = 7 * 24 * 60 * 60  # 604800
 
-    :param gpsweek: Number of weeks since beginning of GPS time (1980-01-06 00:00:00)
-    :param gpsweekseconds: Number of seconds since the GPS week parameter
-    :return: (float) unix timestamp (number of seconds since 1970-01-01 00:00:00)
+    Parameters
+    ----------
+    gpsweek : int
+        Number of weeks since beginning of GPS time (1980-01-06 00:00:00)
+
+    gpsweekseconds : float
+        Number of seconds since the GPS week parameter
+
+    format : {'unix', 'datetime'}
+        Format of returned value
+
+    Returns
+    -------
+    float or :obj:`datetime`
+        UNIX timestamp (number of seconds since 1970-01-01 00:00:00) without
+        leapseconds subtracted if 'unix' is specified for format.
+        Otherwise, a :obj:`datetime` is returned.
     """
     # GPS time begins 1980 Jan 6 00:00, UNIX time begins 1970 Jan 1 00:00
     gps_delta = 315964800.0
@@ -49,45 +86,56 @@ def convert_gps_time(gpsweek, gpsweekseconds, format='unix'):
     if format == 'unix':
         return timestamp
     elif format == 'datetime':
-        return datetime.datetime(1970, 1, 1) + pd.to_timedelta(timestamp, unit='s')
+        return datetime(1970, 1, 1) + pd.to_timedelta(timestamp, unit='s')
+
 
 def leap_seconds(**kwargs):
     """
-    leapseconds :: Variable type -> Integer
+    Look-up for the number of leap seconds for a given date
 
-    Look-up for the number of leapseconds for a given date.
+    Parameters
+    ----------
+    week : int, optional
+        Number of weeks since beginning of GPS time (1980-01-06 00:00:00)
 
-    :param week: Number of weeks since beginning of GPS time (1980-01-06 00:00:00)
-    :param seconds: If week is specified, then seconds of week since the
-                    beginning of Sunday of that week, otherwise, Unix time in
-                    seconds since January 1, 1970 UTC.
-    :param date: Date either in the format MM-DD-YYYY or MM/DD/YYYY
-    :param datetime: datetime-like
-    :return: (integer) Number of accumulated leap seconds as of the given date.
+    seconds : float, optional
+        If week is specified, then seconds of week since the beginning of
+        Sunday of that week, otherwise, Unix time in seconds since
+        January 1, 1970 UTC.
+
+    date : :obj:`str`, optional
+        Date string in the format specified by dateformat.
+
+    dateformat : :obj:`str`, optional
+        Format of the date string if date is used. Default: '%m-%d-%Y'
+
+        .. _Format codes:
+            https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior
+
+    datetime : :obj:`datetime`
+
+    Returns
+    -------
+    int
+        Number of accumulated leap seconds as of the given date.
     """
-
     if 'seconds' in kwargs:
-        # GPS week + seconds of week
         if 'week' in kwargs:
-            dt = (datetime.datetime(1980, 1, 6) +
-                  datetime.timedelta(weeks=kwargs['week']) +
-                  datetime.timedelta(seconds=kwargs['seconds']))
+            dt = (datetime(1980, 1, 6) +
+                  timedelta(weeks=kwargs['week']) +
+                  timedelta(seconds=kwargs['seconds']))
         else:
-        # TO DO: Check for value out of bounds?
-        # week not specified, assume Unix time in seconds
-            dt = (datetime.datetime(1970, 1, 1) +
-                  datetime.timedelta(seconds=kwargs['seconds']))
+            # TODO Check for value out of bounds?
+            dt = (datetime(1970, 1, 1) +
+                  timedelta(seconds=kwargs['seconds']))
 
     elif 'date' in kwargs:
-        d = kwargs['date'].split('-')
-        if len(d) != 3:
-            d = kwargs['date'].split('/')
-            if len(d) != 3:
-                raise ValueError('Date not correctly formatted. '
-                                 'Expect MM-DD-YYYY or MM/DD/YYYY. Got: {date}'
-                                 .format(date=kwargs['date']))
+        if 'dateformat' in kwargs:
+            fmt = kwargs['dateformat']
+        else:
+            fmt = '%m-%d-%Y'
 
-        dt = datetime.datetime(int(d[2]), int(d[0]), int(d[1]))
+        dt = datetime.strptime(kwargs['date'], fmt)
 
     elif 'datetime' in kwargs:
         dt = kwargs['datetime']
@@ -97,41 +145,27 @@ def leap_seconds(**kwargs):
                          'number and seconds of week, Unix time in seconds '
                          'since January 1, 1970 UTC, or datetime.')
 
-    ls_table = [(1980,1,1,1981,7,1),\
-                (1981,7,1,1982,7,1),\
-                (1982,7,1,1983,7,1),\
-                (1983,7,1,1985,7,1),\
-                (1985,7,1,1988,1,1),\
-                (1988,1,1,1990,1,1),\
-                (1990,1,1,1991,1,1),\
-                (1991,1,1,1992,7,1),\
-                (1992,7,1,1993,7,1),\
-                (1993,7,1,1994,7,1),\
-                (1994,7,1,1996,1,1),\
-                (1996,1,1,1997,7,1),\
-                (1997,7,1,1999,1,1),\
-                (1999,1,1,2006,1,1),\
-                (2006,1,1,2009,1,1),\
-                (2009,1,1,2012,7,1),\
-                (2012,7,1,2015,7,1),\
-                (2015,7,1,2017,1,1)]
+    return _get_leap_seconds(dt)
 
-    leap_seconds = 0
-    for entry in ls_table:
-        if (dt >= datetime.datetime(entry[0], entry[1], entry[2]) and
-            dt < datetime.datetime(entry[3],entry[4],entry[5])):
+
+@lru_cache(maxsize=1000)
+def _get_leap_seconds(dt):
+    ls = 0
+    for entry in leap_second_table:
+        if entry[0] <= dt < entry[1]:
             break
-
         else:
-            leap_seconds = leap_seconds + 1
+            ls += 1
+    return ls
 
-    return leap_seconds
 
 def datenum_to_datetime(timestamp):
+    raise NotImplementedError()
+
     if isinstance(timestamp, pd.Series):
-        return (timestamp.astype(int).map(datetime.datetime.fromordinal) +
+        return (timestamp.astype(int).map(datetime.fromordinal) +
                 pd.to_timedelta(timestamp % 1, unit='D') -
                 pd.to_timedelta('366 days'))
     else:
-        return (datetime.datetime.fromordinal(int(timestamp) - 366) +
-                datetime.timedelta(days=timestamp % 1))
+        return (datetime.fromordinal(int(timestamp) - 366) +
+                timedelta(days=timestamp % 1))

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -25,7 +25,7 @@ class TestTimeUtils(unittest.TestCase):
         res_unix = tu.leap_seconds(seconds=unixtime)
         res_datetime = tu.leap_seconds(datetime=dt)
         res_date1 = tu.leap_seconds(date=date1)
-        res_date2 = tu.leap_seconds(date=date2)
+        res_date2 = tu.leap_seconds(date=date2, dateformat='%m/%d/%Y')
 
         self.assertEqual(expected1, res_gps)
         self.assertEqual(expected1, res_unix)
@@ -34,10 +34,10 @@ class TestTimeUtils(unittest.TestCase):
         self.assertEqual(expected2, res_date2)
 
         with self.assertRaises(ValueError):
-            res_date3 = tu.leap_seconds(date=date3)
+            tu.leap_seconds(date=date3)
 
         with self.assertRaises(ValueError):
-            res = tu.leap_seconds(minutes=dt)
+            tu.leap_seconds(minutes=dt)
 
     def test_convert_gps_time(self):
         gpsweek = 1959


### PR DESCRIPTION
- format of dates supplied through 'date' keyword can be specified via the 'dateformat' keyword
- moved leap second table out of function
- converted items in leap second table to tuples of datetimes
- moved leap second lookup to a separate memoized function
- reformed doc strings to NumPy format