### PR TITLE
Bugfix/project api

### DIFF
--- a/dgp/core/controllers/project_controllers.py
+++ b/dgp/core/controllers/project_controllers.py
@@ -153,16 +153,19 @@ class AirborneProjectController(IAirborneController, AttributeProxy):
         self.update()
         return controller
 
-    def remove_child(self, child: Union[Flight, Gravimeter], row: int, confirm=True):
-        if not isinstance(child, (Flight, Gravimeter)):
-            raise ValueError("{0!r} is not a valid child object".format(child))
+    def remove_child(self, uid: Union[OID, str], confirm: bool = True):
+        child = self.get_child(uid)
+        if child is None:
+            self.log.warning(f'UID {uid!s} has no corresponding object in this '
+                             f'project')
+            raise KeyError(f'{uid!s}')
         if confirm:  # pragma: no cover
             if not confirm_action("Confirm Deletion",
                                   "Are you sure you want to delete {!s}"
-                                  .format(child.name)):
+                                  .format(child.get_attr('name'))):
                 return
         self.project.remove_child(child.uid)
-        self._child_map[type(child)].removeRow(row)
+        self._child_map[type(child.datamodel)].removeRow(child.row())
         self.update()
 
     def get_child(self, uid: Union[str, OID]) -> Union[FlightController, GravimeterController, None]:

--- a/dgp/gui/main.py
+++ b/dgp/gui/main.py
@@ -14,7 +14,7 @@ from PyQt5.QtWidgets import QMainWindow, QProgressDialog, QFileDialog, QWidget
 import dgp.core.types.enumerations as enums
 from dgp.core.controllers.project_controllers import AirborneProjectController
 from dgp.core.controllers.flight_controller import FlightController
-from core.controllers.project_treemodel import ProjectTreeModel
+from dgp.core.controllers.project_treemodel import ProjectTreeModel
 from dgp.core.models.project import AirborneProject
 from dgp.gui.utils import (ConsoleHandler, LOG_FORMAT, LOG_LEVEL_MAP,
                            LOG_COLOR_MAP, get_project_file)

--- a/dgp/gui/views/ProjectTreeView.py
+++ b/dgp/gui/views/ProjectTreeView.py
@@ -7,7 +7,7 @@ from PyQt5.QtGui import QContextMenuEvent, QStandardItem
 from PyQt5.QtWidgets import QTreeView, QMenu
 
 from dgp.core.controllers.controller_interfaces import IFlightController, IAirborneController
-from core.controllers.project_treemodel import ProjectTreeModel
+from dgp.core.controllers.project_treemodel import ProjectTreeModel
 
 
 class ProjectTreeView(QTreeView):

--- a/dgp/gui/workspace.py
+++ b/dgp/gui/workspace.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import QWidget, QVBoxLayout, QTabWidget
 import PyQt5.QtWidgets as QtWidgets
 import PyQt5.QtGui as QtGui
 
-from core.controllers.flight_controller import FlightController
+from dgp.core.controllers.flight_controller import FlightController
 from dgp.core.oid import OID
 from .workspaces import *
 

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -177,16 +177,16 @@ def test_airborne_project_controller(project):
     assert flight2 == fc2.datamodel
 
     assert 5 == project_ctrl.flights.rowCount()
-    project_ctrl.remove_child(flight2, fc2.row(), confirm=False)
+    project_ctrl.remove_child(flight2.uid, confirm=False)
     assert 4 == project_ctrl.flights.rowCount()
     assert project_ctrl.get_child(fc2.uid) is None
 
     assert 3 == project_ctrl.meters.rowCount()
-    project_ctrl.remove_child(meter, mc.row(), confirm=False)
+    project_ctrl.remove_child(meter.uid, confirm=False)
     assert 2 == project_ctrl.meters.rowCount()
 
-    with pytest.raises(ValueError):
-        project_ctrl.remove_child("Not a child", 2)
+    with pytest.raises(KeyError):
+        project_ctrl.remove_child("Not a child")
 
     jsons = project_ctrl.save(to_file=False)
     assert isinstance(jsons, str)


### PR DESCRIPTION
Fixes a bug in the Flight/Project controller which was causing a crash when attempting to delete a flight via the right-click context menu (see issue #73 ) 
Also fixes some incorrect import statements (generated by my IDE) which weren't caught earlier, these could lead to crashes/import errors depending on the Python Path setting and/or current working directory when the application is launched.

Adds testing for the FlightController menu bindings. The testing is limited to non-interactive actions (i.e. actions that don't spawn a dialog) due to the way dialogs are currently created.
Test was also added to FlightController to verify the structure of the _bindings list, ensuring that the format of the menu declaration is valid.

---
Resolves #73 