### PR TITLE
Update dependencies

### DIFF
--- a/dgp/lib/trajectory_ingestor.py
+++ b/dgp/lib/trajectory_ingestor.py
@@ -7,9 +7,9 @@ Library for trajectory data import functions
 """
 import numpy as np
 import pandas as pd
+from pandas.tseries.offsets import Milli
 
 from .time_utils import leap_seconds, convert_gps_time, datenum_to_datetime
-from .etc import interp_nans
 
 
 TRAJECTORY_INTERP_FIELDS = {'lat', 'long', 'ell_ht'}
@@ -97,6 +97,7 @@ def import_trajectory(filepath, delim_whitespace=False, interval=0,
     # create index
     if timeformat == 'sow':
         df.index = convert_gps_time(df['week'], df['sow'], format='datetime')
+        df.index = df.index.round(Milli())
         df.drop(['sow', 'week'], axis=1, inplace=True)
     elif timeformat == 'hms':
         df.index = pd.to_datetime(df['mdy'].str.strip() + df['hms'].str.strip(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Project Requirements
 matplotlib>=2.0.2
 numpy>=1.13.1
-pandas==0.20.3
+pandas==0.23.3
 PyQt5==5.11.2
 pyqtgraph==0.10.0
-tables==3.4.2
+tables==3.4.4
 scipy==1.1.0


### PR DESCRIPTION
Just a small update for the tables and pandas versions.

Tables version was updated because there were some issues with getting the latest available version of HDF5 for OS X to work with the previously used version of tables.

Pandas was updated to 0.23.3. The upgrade caused tests for trajectory_ingestor to fail due to timestamp round-off. Now, if a trajectory comes in with GPS week and second-of-week, then timestamps in the index are rounded to the nearest millisecond. 