### PR TITLE
Feature/fixup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ DGP (Dynamic Gravity Processor)
     :target: https://ci.appveyor.com/project/bradyzp/dgp
 
 .. image:: https://coveralls.io/repos/github/DynamicGravitySystems/DGP/badge.svg?branch=feature%2Fproject-structure
-    :target: https://coveralls.io/github/DynamicGravitySystems/DGP?branch=feature%2Fproject-structure
+    :target: https://coveralls.io/github/DynamicGravitySystems/DGP?branch=develop
 
 .. image:: https://readthedocs.org/projects/dgp/badge/?version=develop
     :target: https://dgp.readthedocs.io/en/develop

--- a/dgp/lib/trajectory_ingestor.py
+++ b/dgp/lib/trajectory_ingestor.py
@@ -110,7 +110,7 @@ def import_trajectory(filepath, delim_whitespace=False, interval=0,
     # remove leap second
     if is_utc:
         # TO DO: Check dates at beginning and end to determine whether a leap second was added in the middle of the survey.
-        shift = leap_seconds(df.index[0])
+        shift = leap_seconds(datetime=df.index[0])
         df.index = df.index.shift(-shift, freq='S')
 
     # set or infer the interval

--- a/tests/test_timesync.py
+++ b/tests/test_timesync.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import os
 
 from .context import dgp
 import unittest
@@ -8,6 +9,7 @@ import pandas as pd
 from dgp.lib.timesync import find_time_delay, shift_frame
 
 
+@unittest.skipIf(os.getenv("development", False), "Skip slow unit-tests in dev env")
 class TestTimesync(unittest.TestCase):
     def test_timedelay_array(self):
         rnd_offset = 1.1


### PR DESCRIPTION
Minor quality-of-life improvements in the project and tests.

- Fix the trajectory ingestor leap_seconds invocation in load_trajectory, it was raising an exception because leap_seconds does not accept positional arguments.
- Update the coveralls badge, the path was incorrectly pointing to an old branch coverage report.
- Added a conditional skip to the timesync test suite, these tests can take a while and it's nice to disable them during development. Environment variable must be explicitly set for "develop", so everything will still run by default on CI.