### PR TITLE
Fix for timestamp round-off issue in convert_gps_time

### DIFF
--- a/dgp/lib/time_utils.py
+++ b/dgp/lib/time_utils.py
@@ -85,9 +85,13 @@ def convert_gps_time(gpsweek, gpsweekseconds, format='unix'):
 
     if format == 'unix':
         return timestamp
-    elif format == 'datetime':
-        return datetime(1970, 1, 1) + pd.to_timedelta(timestamp, unit='s')
 
+    elif format == 'datetime':
+        result = datetime(1970, 1, 1) + pd.to_timedelta(timestamp, unit='s')
+
+        if not isinstance(result, datetime):
+            return result.dt.ceil('1000N')
+        return result
 
 def leap_seconds(**kwargs):
     """
@@ -160,12 +164,11 @@ def _get_leap_seconds(dt):
 
 
 def datenum_to_datetime(timestamp):
-    raise NotImplementedError()
-
-    if isinstance(timestamp, pd.Series):
-        return (timestamp.astype(int).map(datetime.fromordinal) +
-                pd.to_timedelta(timestamp % 1, unit='D') -
-                pd.to_timedelta('366 days'))
-    else:
-        return (datetime.fromordinal(int(timestamp) - 366) +
-                timedelta(days=timestamp % 1))
+    raise NotImplementedError
+    # if isinstance(timestamp, pd.Series):
+    #     return (timestamp.astype(int).map(datetime.fromordinal) +
+    #             pd.to_timedelta(timestamp % 1, unit='D') -
+    #             pd.to_timedelta('366 days'))
+    # else:
+    #     return (datetime.fromordinal(int(timestamp) - 366) +
+    #             timedelta(days=timestamp % 1))

--- a/dgp/lib/time_utils.py
+++ b/dgp/lib/time_utils.py
@@ -87,11 +87,7 @@ def convert_gps_time(gpsweek, gpsweekseconds, format='unix'):
         return timestamp
 
     elif format == 'datetime':
-        result = datetime(1970, 1, 1) + pd.to_timedelta(timestamp, unit='s')
-
-        if not isinstance(result, datetime):
-            return result.dt.ceil('1000N')
-        return result
+        return datetime(1970, 1, 1) + pd.to_timedelta(timestamp * 1e9)
 
 def leap_seconds(**kwargs):
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,8 @@ def shim_settings():
     settings = QSettings(QSettings.IniFormat, QSettings.UserScope, "DgS", "DGP")
     set_settings(settings)
     yield
-    os.unlink(settings.fileName())
+    if os.path.exists(settings.fileName()):
+        os.unlink(settings.fileName())
 
 
 def qt_msg_handler(type_, context, message: str):

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -51,7 +51,7 @@ def test_convert_gps_time():
         (312030.8, datetime(2017, 3, 22, 14, 40, 30, 800000)),
         (312030.08, datetime(2017, 3, 22, 14, 40, 30, 80000)),
         (312030.008, datetime(2017, 3, 22, 14, 40, 30, 8000)),
-        (312030.0008, datetime(2017, 3, 22, 14, 40, 30, 800)),
+        (312030.0008, datetime(2017, 3, 22, 14, 40, 30, 800))
     ]
 )
 def test_convert_gps_time_datetime(given_sow, expected_dt):

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,66 +1,76 @@
 # coding: utf-8
-import os
-import unittest
+import pytest
 from datetime import datetime
 import pandas as pd
 
 from dgp.lib import time_utils as tu
 
-class TestTimeUtils(unittest.TestCase):
-    def test_leap_seconds(self):
-        # TO DO: Test edge cases
-        gpsweek = 1959
-        gpsweeksecond = 219698.000
-        unixtime = 1500987698  # 2017-07-25 13:01:38+00:00
-        dt = datetime.strptime('2017-07-25 13:01:38', '%Y-%m-%d %H:%M:%S')
-        expected1 = 18
 
-        date1 = '08-07-2015'
-        date2 = '08/07/2015'
-        date3 = '08/07-2015'
-        expected2 = 17
+def test_leap_seconds():
+    # TO DO: Test edge cases
+    gpsweek = 1959
+    gpsweeksecond = 219698.000
+    unixtime = 1500987698  # 2017-07-25 13:01:38+00:00
+    dt = datetime.strptime('2017-07-25 13:01:38', '%Y-%m-%d %H:%M:%S')
+    expected1 = 18
 
-        res_gps = tu.leap_seconds(week=gpsweek, seconds=gpsweeksecond)
-        res_unix = tu.leap_seconds(seconds=unixtime)
-        res_datetime = tu.leap_seconds(datetime=dt)
-        res_date1 = tu.leap_seconds(date=date1)
-        res_date2 = tu.leap_seconds(date=date2, dateformat='%m/%d/%Y')
+    date1 = '08-07-2015'
+    date2 = '08/07/2015'
+    date3 = '08/07-2015'
+    expected2 = 17
 
-        self.assertEqual(expected1, res_gps)
-        self.assertEqual(expected1, res_unix)
-        self.assertEqual(expected1, res_datetime)
-        self.assertEqual(expected2, res_date1)
-        self.assertEqual(expected2, res_date2)
+    res_gps = tu.leap_seconds(week=gpsweek, seconds=gpsweeksecond)
+    res_unix = tu.leap_seconds(seconds=unixtime)
+    res_datetime = tu.leap_seconds(datetime=dt)
+    res_date1 = tu.leap_seconds(date=date1)
+    res_date2 = tu.leap_seconds(date=date2, dateformat='%m/%d/%Y')
 
-        with self.assertRaises(ValueError):
-            tu.leap_seconds(date=date3)
+    assert expected1 == res_gps
+    assert expected1 == res_unix
+    assert expected1 == res_datetime
+    assert expected2 == res_date1
+    assert expected2 == res_date2
 
-        with self.assertRaises(ValueError):
-            tu.leap_seconds(minutes=dt)
+    with pytest.raises(ValueError):
+        tu.leap_seconds(date=date3)
 
-    def test_convert_gps_time(self):
-        gpsweek = 1959
-        gpsweeksecond = 219698.000
-        result = 1500987698  # 2017-07-25 13:01:38+00:00
-        test_res = tu.convert_gps_time(gpsweek, gpsweeksecond)
-        self.assertEqual(result, test_res)
+    with pytest.raises(ValueError):
+        tu.leap_seconds(minutes=dt)
 
-    def test_datetime_to_sow(self):
-        # test single input
-        dt = datetime(2017, 9, 7, hour=13)
-        expected = (1965, 392400)
-        given = tu.datetime_to_sow(dt)
-        self.assertEqual(expected, given)
 
-        # test iterable input
-        dt_series = pd.Series([dt]*20)
-        expected_iter = [expected]*20
-        given_iter = tu.datetime_to_sow(dt_series)
-        self.assertEqual(expected_iter, given_iter)
+def test_convert_gps_time():
+    gpsweek = 1959
+    gpsweeksecond = 219698.000
+    result = 1500987698  # 2017-07-25 13:01:38+00:00
+    test_res = tu.convert_gps_time(gpsweek, gpsweeksecond)
+    assert result == test_res
 
-    def test_datenum_to_datetime(self):
-        pass
-        # datenum = 736945.5416667824
-        # given = tu.datenum_to_datetime(datenum)
-        # expected = datetime(2017, 9, 7, hour=13, microsecond=10000)
-        # self.assertEqual(expected, given)
+
+@pytest.mark.parametrize(
+    'given_sow, expected_dt', [
+        (312030.8, datetime(2017, 3, 22, 14, 40, 30, 800000)),
+        (312030.08, datetime(2017, 3, 22, 14, 40, 30, 80000)),
+        (312030.008, datetime(2017, 3, 22, 14, 40, 30, 8000)),
+        (312030.0008, datetime(2017, 3, 22, 14, 40, 30, 800)),
+    ]
+)
+def test_convert_gps_time_datetime(given_sow, expected_dt):
+    gpsweek = pd.Series([1941])
+    gpsweeksecond = pd.Series([given_sow])
+    result = pd.Series([expected_dt])
+    test_res = tu.convert_gps_time(gpsweek, gpsweeksecond, format='datetime')
+    assert result.equals(test_res)
+
+
+def test_datetime_to_sow():
+    # test single input
+    dt = datetime(2017, 9, 7, hour=13)
+    expected = (1965, 392400)
+    given = tu.datetime_to_sow(dt)
+    assert expected == given
+
+    # test iterable input
+    dt_series = pd.Series([dt]*20)
+    expected_iter = [expected]*20
+    given_iter = tu.datetime_to_sow(dt_series)
+    assert expected_iter == given_iter


### PR DESCRIPTION
The underlying issue exposed in Issue #85 is due to a bug in a low-level function in the pandas library that converts timestamps of any unit into integers in nanoseconds.  The fix in this PR should be considered temporary until the associated issue in pandas is fixed.

By passing a timestamp in nanoseconds to the pandas `to_timedelta` function, rather than a timestamp in seconds, the problematic code path in the pandas library is avoided.

Unit tests for the `datetime_to_sow` function were also included in this PR to catch this issue in the future.

Closes Issue #85 