### PR TITLE
Feature/reference tracking

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ branch = True
 omit =
     dgp/resources_rc.py
     dgp/gui/ui/*.py
+    dgp/__main__.py
 
 exclude_lines =
     pragma: no cover

--- a/dgp/__main__.py
+++ b/dgp/__main__.py
@@ -10,8 +10,10 @@ from PyQt5.QtWidgets import QApplication, QSplashScreen
 
 from dgp.gui.main import MainWindow
 
+app = None
 
-def excepthook(type_, value, traceback_):  # pragma: no cover
+
+def excepthook(type_, value, traceback_):
     """This allows IDE to properly display unhandled exceptions which are
     otherwise silently ignored as the application is terminated.
     Override default excepthook with
@@ -23,11 +25,8 @@ def excepthook(type_, value, traceback_):  # pragma: no cover
     QtCore.qFatal('')
 
 
-app = None
-_align = Qt.AlignBottom | Qt.AlignHCenter
-
-
-def main():  # pragma: no cover
+def main():
+    _align = Qt.AlignBottom | Qt.AlignHCenter
     global app
     sys.excepthook = excepthook
     app = QApplication(sys.argv)

--- a/dgp/core/controllers/controller_interfaces.py
+++ b/dgp/core/controllers/controller_interfaces.py
@@ -28,8 +28,11 @@ MaybeChild = Union['AbstractController', None]
 class AbstractController(QStandardItem, AttributeProxy):
     """AbstractController provides a base interface for creating Controllers
 
+    .. versionadded:: 0.1.0
+
     This class provides some concrete implementations for various features
     common to all controllers:
+
         - Encapsulation of a model (dgp.core.models) object
         - Exposure of the underlying model entities' UID
         - Observer registration (notify observers on StateAction's)
@@ -37,10 +40,12 @@ class AbstractController(QStandardItem, AttributeProxy):
         - Child lookup function (get_child) to find child by its UID
 
     The following methods must be explicitly implemented by subclasses:
+
         - clone()
         - menu @property
 
     The following methods may be optionally implemented by subclasses:
+
         - children @property
         - add_child()
         - remove_child()
@@ -49,10 +54,10 @@ class AbstractController(QStandardItem, AttributeProxy):
     ----------
     model
         The underlying model (from dgp.core.models) entity of this controller
-    project : IAirborneController, optional
+    project : :class:`IAirborneController`, optional
         A weak-reference is stored to the project controller for direct access
-        by the controller via the :prop:`project` @property
-    parent : AbstractController, optional
+        by the controller via the :meth:`project` @property
+    parent : :class:`AbstractController`, optional
         A strong-reference is maintained to the parent controller object,
         accessible via the :meth:`get_parent` method
     *args
@@ -71,6 +76,7 @@ class AbstractController(QStandardItem, AttributeProxy):
     updates to any observers automatically.
 
     """
+
     def __init__(self, model, *args, project=None, parent=None, **kwargs):
         super().__init__(*args, **kwargs)
         self._model = model
@@ -87,7 +93,14 @@ class AbstractController(QStandardItem, AttributeProxy):
 
     @property
     def uid(self) -> OID:
-        """Return the unique Object IDentifier for the controllers' model"""
+        """Return the unique Object IDentifier for the controllers' model
+
+        Returns
+        -------
+        oid : :class:`~dgp.core.OID`
+            Unique Identifier of this Controller/Entity
+
+        """
         return self._model.uid
 
     @property
@@ -97,11 +110,24 @@ class AbstractController(QStandardItem, AttributeProxy):
 
     @property
     def project(self) -> 'IAirborneController':
+        """Return a reference to the top-level project owner of this controller
+
+        Returns
+        -------
+        :class:`IAirborneController` or :const:`None`
+
+        """
         return self._project() if self._project is not None else None
 
     @property
     def clones(self):
-        """Yields any active (referenced) clones of this controller"""
+        """Yields any active (referenced) clones of this controller
+
+        Yields
+        ------
+        :class:`AbstractController`
+
+        """
         for clone in self._clones:
             yield clone
 
@@ -111,18 +137,40 @@ class AbstractController(QStandardItem, AttributeProxy):
         Must be overridden by subclasses, subclasses should call register_clone
         on the cloned instance to ensure update events are propagated to the
         clone.
+
+        Returns
+        -------
+        :class:`AbstractController`
+            Clone of this controller with a shared reference to the entity
+
         """
         raise NotImplementedError
 
     @property
     def is_clone(self) -> bool:
+        """Determine if this controller is a clone
+
+        Returns
+        -------
+        bool
+            True if this controller is a clone, else False
+
+        """
         return self.__cloned
 
     @is_clone.setter
     def is_clone(self, value: bool):
         self.__cloned = value
 
-    def register_clone(self, clone: 'AbstractController'):
+    def register_clone(self, clone: 'AbstractController') -> None:
+        """Registers a cloned copy of this controller for updates
+
+        Parameters
+        ----------
+        clone : :class:`AbstractController`
+            The cloned copy of the root controller to register
+
+        """
         clone.is_clone = True
         self._clones.add(clone)
 
@@ -141,20 +189,39 @@ class AbstractController(QStandardItem, AttributeProxy):
 
     @property
     def parent_widget(self) -> Union[QWidget, None]:
-        """Returns the parent QWidget of this items' QAbstractModel"""
+        """Get the parent QWidget of this items' QAbstractModel
+
+        Returns
+        -------
+        :class:`pyqt.QWidget` or :const:`None`
+            QWidget parent if it exists, else None
+        """
         try:
             return self.model().parent()
         except AttributeError:
             return None
 
     def get_parent(self) -> 'AbstractController':
+        """Get the parent controller of this controller
+
+        Notes
+        -----
+        :meth:`get_parent` and  :meth:`set_parent` are defined as methods to
+        avoid naming conflicts with :class:`pyqt.QStandardItem` parent method.
+
+        Returns
+        -------
+        :class:`AbstractController` or None
+            Parent controller (if it exists) of this controller
+
+        """
         return self._parent
 
     def set_parent(self, parent: 'AbstractController'):
         self._parent = parent
 
     def register_observer(self, observer, callback, state: StateAction) -> None:
-        """Register an observer with this controller
+        """Register an observer callback with this controller for the given state
 
         Observers will be notified when the controller undergoes the applicable
         StateAction (UPDATE/DELETE), via the supplied callback method.
@@ -189,9 +256,7 @@ class AbstractController(QStandardItem, AttributeProxy):
             clone.delete()
 
     def update(self) -> None:
-        """Notify any observers and clones that the controller state has updated
-
-        """
+        """Notify observers and clones that the controller has updated"""
         for cb in self._observers[StateAction.UPDATE].values():
             cb()()
         for clone in self.clones:
@@ -205,8 +270,8 @@ class AbstractController(QStandardItem, AttributeProxy):
 
         Yields
         ------
-        AbstractController
-            Children of this controller
+        :class:`AbstractController`
+            Child controllers
 
         """
         yield from ()
@@ -228,7 +293,7 @@ class AbstractController(QStandardItem, AttributeProxy):
         Raises
         ------
         :exc:`TypeError`
-            If the child is not an allowed type for the controller.
+            If the child is not a permissible type for the controller.
         """
         pass
 
@@ -262,7 +327,7 @@ class AbstractController(QStandardItem, AttributeProxy):
 
         Returns
         -------
-        MaybeChild
+        :const:`MaybeChild`
             Returns the child controller object referred to by uid if it exists
             else None
 

--- a/dgp/core/controllers/controller_interfaces.py
+++ b/dgp/core/controllers/controller_interfaces.py
@@ -153,14 +153,17 @@ class AbstractController(QStandardItem, AttributeProxy):
 
     @property
     def children(self) -> Generator['AbstractController', None, None]:
-        """Return a generator of IChild objects specific to the parent.
+        """Yields children of this controller
 
-        Returns
-        -------
-        Generator[AbstractController, None, None]
+        Override this property to provide generic access to controller children
+
+        Yields
+        ------
+        AbstractController
+            Children of this controller
 
         """
-        raise NotImplementedError
+        yield from ()
 
     def add_child(self, child) -> 'AbstractController':
         """Add a child object to the controller, and its underlying
@@ -181,16 +184,29 @@ class AbstractController(QStandardItem, AttributeProxy):
         :exc:`TypeError`
             If the child is not an allowed type for the controller.
         """
-        if self.children is None:
-            raise TypeError(f"{self.__class__} does not support children")
-        raise NotImplementedError
+        pass
 
-    def remove_child(self, child, confirm: bool = True) -> bool:
-        if self.children is None:
-            return False
-        raise NotImplementedError
+    def remove_child(self, uid: OID, confirm: bool = True) -> bool:
+        """Remove a child from this controller, and notify the child of its deletion
 
-    def get_child(self, uid: Union[str, OID]) -> MaybeChild:
+        Parameters
+        ----------
+        uid : OID
+            OID of the child to remove
+        confirm : bool, optional
+            Optionally request that the controller confirms the action before
+            removing the child, default is True
+
+        Returns
+        -------
+        bool
+            True on successful removal of child
+            False on failure (i.e. invalid uid supplied)
+
+        """
+        pass
+
+    def get_child(self, uid: OID) -> MaybeChild:
         """Get a child of this object by matching OID
 
         Parameters
@@ -200,8 +216,8 @@ class AbstractController(QStandardItem, AttributeProxy):
 
         Returns
         -------
-        IChild or None
-            Returns the child object referred to by uid if it exists
+        MaybeChild
+            Returns the child controller object referred to by uid if it exists
             else None
 
         """
@@ -209,11 +225,14 @@ class AbstractController(QStandardItem, AttributeProxy):
             if uid == child.uid:
                 return child
 
-    @property
-    def datamodel(self) -> object:
-        raise NotImplementedError
+    def __str__(self):
+        return str(self.entity)
+
+    def __hash__(self):
+        return hash(self.uid)
 
 
+# noinspection PyAbstractClass
 class IAirborneController(AbstractController):
     def add_flight_dlg(self):
         raise NotImplementedError
@@ -243,15 +262,17 @@ class IAirborneController(AbstractController):
         raise NotImplementedError
 
 
+# noinspection PyAbstractClass
 class IFlightController(AbstractController):
-    def get_parent(self) -> IAirborneController:
-        raise NotImplementedError
+    pass
 
 
+# noinspection PyAbstractClass
 class IMeterController(AbstractController):
     pass
 
 
+# noinspection PyAbstractClass
 class IDataSetController(AbstractController):
     @property
     def hdfpath(self) -> Path:
@@ -269,25 +290,5 @@ class IDataSetController(AbstractController):
         """
         raise NotImplementedError
 
-    def add_segment(self, uid: OID, start: float, stop: float,
-                    label: str = ""):
-        raise NotImplementedError
-
-    def get_segment(self, uid: OID):
-        raise NotImplementedError
-
-    def remove_segment(self, uid: OID) -> None:
-        """
-        Removes the specified data-segment from the DataSet.
-
-        Parameters
-        ----------
-        uid : :obj:`OID`
-            uid (OID or str) of the segment to be removed
-
-        Raises
-        ------
-        :exc:`KeyError` if supplied uid is not contained within the DataSet
-
-        """
+    def get_datafile(self, group):
         raise NotImplementedError

--- a/dgp/core/controllers/controller_interfaces.py
+++ b/dgp/core/controllers/controller_interfaces.py
@@ -54,7 +54,7 @@ class AbstractController(QStandardItem, AttributeProxy):
     ----------
     model
         The underlying model (from dgp.core.models) entity of this controller
-    project : :class:`IAirborneController`, optional
+    project : :class:`IAirborneController`
         A weak-reference is stored to the project controller for direct access
         by the controller via the :meth:`project` @property
     parent : :class:`AbstractController`, optional
@@ -77,7 +77,7 @@ class AbstractController(QStandardItem, AttributeProxy):
 
     """
 
-    def __init__(self, model, *args, project=None, parent=None, **kwargs):
+    def __init__(self, model, project, *args, parent=None, **kwargs):
         super().__init__(*args, **kwargs)
         self._model = model
         self._project = ref(project) if project is not None else None

--- a/dgp/core/controllers/controller_interfaces.py
+++ b/dgp/core/controllers/controller_interfaces.py
@@ -26,6 +26,51 @@ MaybeChild = Union['AbstractController', None]
 
 
 class AbstractController(QStandardItem, AttributeProxy):
+    """AbstractController provides a base interface for creating Controllers
+
+    This class provides some concrete implementations for various features
+    common to all controllers:
+        - Encapsulation of a model (dgp.core.models) object
+        - Exposure of the underlying model entities' UID
+        - Observer registration (notify observers on StateAction's)
+        - Clone registration (notify clones of updates to the base object)
+        - Child lookup function (get_child) to find child by its UID
+
+    The following methods must be explicitly implemented by subclasses:
+        - clone()
+        - menu @property
+
+    The following methods may be optionally implemented by subclasses:
+        - children @property
+        - add_child()
+        - remove_child()
+
+    Parameters
+    ----------
+    model
+        The underlying model (from dgp.core.models) entity of this controller
+    project : IAirborneController, optional
+        A weak-reference is stored to the project controller for direct access
+        by the controller via the :prop:`project` @property
+    parent : AbstractController, optional
+        A strong-reference is maintained to the parent controller object,
+        accessible via the :meth:`get_parent` method
+    *args
+        Positional arguments are supplied to the QStandardItem constructor
+    *kwargs
+        Keyword arguments are supplied to the QStandardItem constructor
+
+    Notes
+    -----
+    When removing/deleting a controller, the delete() method should be called on
+    the child, in order for it to notify any subscribers of its impending doom.
+
+    The update method should be extended by subclasses in order to perform
+    visual updates (e.g. Item text, tooltips) when an entity attribute has been
+    updated (via AttributeProxy::set_attr), call the super() method to propagate
+    updates to any observers automatically.
+
+    """
     def __init__(self, model, *args, project=None, parent=None, **kwargs):
         super().__init__(*args, **kwargs)
         self._model = model
@@ -96,6 +141,7 @@ class AbstractController(QStandardItem, AttributeProxy):
 
     @property
     def parent_widget(self) -> Union[QWidget, None]:
+        """Returns the parent QWidget of this items' QAbstractModel"""
         try:
             return self.model().parent()
         except AttributeError:

--- a/dgp/core/controllers/controller_interfaces.py
+++ b/dgp/core/controllers/controller_interfaces.py
@@ -22,11 +22,11 @@ level classes also subclass QStandardItem and/or AttributeProxy.
 """
 
 MenuBinding = Tuple[str, Tuple[Any, ...]]
-MaybeChild = Union['AbstractController', None]
+MaybeChild = Union['VirtualBaseController', None]
 
 
-class AbstractController(QStandardItem, AttributeProxy):
-    """AbstractController provides a base interface for creating Controllers
+class VirtualBaseController(QStandardItem, AttributeProxy):
+    """VirtualBaseController provides a base interface for creating Controllers
 
     .. versionadded:: 0.1.0
 
@@ -57,7 +57,7 @@ class AbstractController(QStandardItem, AttributeProxy):
     project : :class:`IAirborneController`
         A weak-reference is stored to the project controller for direct access
         by the controller via the :meth:`project` @property
-    parent : :class:`AbstractController`, optional
+    parent : :class:`VirtualBaseController`, optional
         A strong-reference is maintained to the parent controller object,
         accessible via the :meth:`get_parent` method
     *args
@@ -81,8 +81,8 @@ class AbstractController(QStandardItem, AttributeProxy):
         super().__init__(*args, **kwargs)
         self._model = model
         self._project = ref(project) if project is not None else None
-        self._parent: AbstractController = parent
-        self._clones: Set[AbstractController] = WeakSet()
+        self._parent: VirtualBaseController = parent
+        self._clones: Set[VirtualBaseController] = WeakSet()
         self.__cloned = False
         self._observers: Dict[StateAction, Dict] = {state: WeakKeyDictionary()
                                                     for state in StateAction}
@@ -125,7 +125,7 @@ class AbstractController(QStandardItem, AttributeProxy):
 
         Yields
         ------
-        :class:`AbstractController`
+        :class:`VirtualBaseController`
 
         """
         for clone in self._clones:
@@ -140,7 +140,7 @@ class AbstractController(QStandardItem, AttributeProxy):
 
         Returns
         -------
-        :class:`AbstractController`
+        :class:`VirtualBaseController`
             Clone of this controller with a shared reference to the entity
 
         """
@@ -162,12 +162,12 @@ class AbstractController(QStandardItem, AttributeProxy):
     def is_clone(self, value: bool):
         self.__cloned = value
 
-    def register_clone(self, clone: 'AbstractController') -> None:
+    def register_clone(self, clone: 'VirtualBaseController') -> None:
         """Registers a cloned copy of this controller for updates
 
         Parameters
         ----------
-        clone : :class:`AbstractController`
+        clone : :class:`VirtualBaseController`
             The cloned copy of the root controller to register
 
         """
@@ -201,7 +201,7 @@ class AbstractController(QStandardItem, AttributeProxy):
         except AttributeError:
             return None
 
-    def get_parent(self) -> 'AbstractController':
+    def get_parent(self) -> 'VirtualBaseController':
         """Get the parent controller of this controller
 
         Notes
@@ -211,13 +211,13 @@ class AbstractController(QStandardItem, AttributeProxy):
 
         Returns
         -------
-        :class:`AbstractController` or None
+        :class:`VirtualBaseController` or None
             Parent controller (if it exists) of this controller
 
         """
         return self._parent
 
-    def set_parent(self, parent: 'AbstractController'):
+    def set_parent(self, parent: 'VirtualBaseController'):
         self._parent = parent
 
     def register_observer(self, observer, callback, state: StateAction) -> None:
@@ -263,20 +263,20 @@ class AbstractController(QStandardItem, AttributeProxy):
             clone.update()
 
     @property
-    def children(self) -> Generator['AbstractController', None, None]:
+    def children(self) -> Generator['VirtualBaseController', None, None]:
         """Yields children of this controller
 
         Override this property to provide generic access to controller children
 
         Yields
         ------
-        :class:`AbstractController`
+        :class:`VirtualBaseController`
             Child controllers
 
         """
         yield from ()
 
-    def add_child(self, child) -> 'AbstractController':
+    def add_child(self, child) -> 'VirtualBaseController':
         """Add a child object to the controller, and its underlying
         data object.
 
@@ -287,7 +287,7 @@ class AbstractController(QStandardItem, AttributeProxy):
 
         Returns
         -------
-        :class:`AbstractController`
+        :class:`VirtualBaseController`
             A reference to the controller object wrapping the added child
 
         Raises
@@ -344,7 +344,7 @@ class AbstractController(QStandardItem, AttributeProxy):
 
 
 # noinspection PyAbstractClass
-class IAirborneController(AbstractController):
+class IAirborneController(VirtualBaseController):
     def add_flight_dlg(self):
         raise NotImplementedError
 
@@ -374,17 +374,17 @@ class IAirborneController(AbstractController):
 
 
 # noinspection PyAbstractClass
-class IFlightController(AbstractController):
+class IFlightController(VirtualBaseController):
     pass
 
 
 # noinspection PyAbstractClass
-class IMeterController(AbstractController):
+class IMeterController(VirtualBaseController):
     pass
 
 
 # noinspection PyAbstractClass
-class IDataSetController(AbstractController):
+class IDataSetController(VirtualBaseController):
     @property
     def hdfpath(self) -> Path:
         raise NotImplementedError

--- a/dgp/core/controllers/controller_interfaces.py
+++ b/dgp/core/controllers/controller_interfaces.py
@@ -182,19 +182,6 @@ class IParent(DGPObject):
         else:
             return child
 
-    @property
-    def active_child(self) -> MaybeChild:
-        """Get the active child of this parent.
-
-        Returns
-        -------
-        IChild, None
-            The first active child, or None if there are no children which are
-            active.
-
-        """
-        return next((child for child in self.children if child.is_active), None)
-
 
 class IBaseController(QStandardItem, AttributeProxy, DGPObject):
     @property

--- a/dgp/core/controllers/controller_mixins.py
+++ b/dgp/core/controllers/controller_mixins.py
@@ -13,7 +13,7 @@ class AttributeProxy:
     """
 
     @property
-    def datamodel(self) -> object:
+    def entity(self) -> object:
         """Return the underlying model of the proxy class."""
         raise NotImplementedError
 
@@ -24,14 +24,14 @@ class AttributeProxy:
         pass
 
     def get_attr(self, key: str) -> Any:
-        if hasattr(self.datamodel, key):
-            return getattr(self.datamodel, key)
+        if hasattr(self.entity, key):
+            return getattr(self.entity, key)
         else:
-            raise AttributeError("Object {!r} has no attribute {}".format(self.datamodel, key))
+            raise AttributeError("Object {!r} has no attribute {}".format(self.entity, key))
 
     def set_attr(self, key: str, value: Any):
-        if not hasattr(self.datamodel, key):
-            raise AttributeError("Object {!r} has no attribute {}".format(self.datamodel, key))
+        if not hasattr(self.entity, key):
+            raise AttributeError("Object {!r} has no attribute {}".format(self.entity, key))
         if not self.writeable(key):
             raise AttributeError("Attribute [{}] is not writeable".format(key))
 
@@ -41,7 +41,7 @@ class AttributeProxy:
             if not valid == QValidator.Acceptable:
                 raise ValueError("Value does not pass validation")
 
-        setattr(self.datamodel, key, value)
+        setattr(self.entity, key, value)
         self.update()
 
     def writeable(self, key: str) -> bool:

--- a/dgp/core/controllers/datafile_controller.py
+++ b/dgp/core/controllers/datafile_controller.py
@@ -9,13 +9,13 @@ from dgp.core import DataType
 from dgp.core.hdf5_manager import HDF5Manager
 from dgp.core.oid import OID
 from dgp.core.types.enumerations import Icon
-from dgp.core.controllers.controller_interfaces import IDataSetController, AbstractController
+from dgp.core.controllers.controller_interfaces import IDataSetController, VirtualBaseController
 from dgp.core.controllers.controller_helpers import show_in_explorer
 from dgp.core.models.datafile import DataFile
 
 
-class DataFileController(AbstractController):
-    def __init__(self, datafile: DataFile, project: AbstractController,
+class DataFileController(VirtualBaseController):
+    def __init__(self, datafile: DataFile, project: VirtualBaseController,
                  parent: IDataSetController = None):
         super().__init__(datafile, project, parent=parent)
         self.log = logging.getLogger(__name__)

--- a/dgp/core/controllers/datafile_controller.py
+++ b/dgp/core/controllers/datafile_controller.py
@@ -15,9 +15,9 @@ from dgp.core.models.datafile import DataFile
 
 
 class DataFileController(AbstractController):
-
-    def __init__(self, datafile: DataFile, parent: IDataSetController = None):
-        super().__init__(model=datafile, parent=parent)
+    def __init__(self, datafile: DataFile, project: AbstractController,
+                 parent: IDataSetController = None):
+        super().__init__(datafile, project, parent=parent)
         self.log = logging.getLogger(__name__)
 
         self.set_datafile(datafile)

--- a/dgp/core/controllers/datafile_controller.py
+++ b/dgp/core/controllers/datafile_controller.py
@@ -7,12 +7,12 @@ from dgp.core import DataType
 from dgp.core.hdf5_manager import HDF5Manager
 from dgp.core.oid import OID
 from dgp.core.types.enumerations import Icon
-from dgp.core.controllers.controller_interfaces import IDataSetController, IBaseController
+from dgp.core.controllers.controller_interfaces import IDataSetController, AbstractController
 from dgp.core.controllers.controller_helpers import show_in_explorer
 from dgp.core.models.datafile import DataFile
 
 
-class DataFileController(IBaseController):
+class DataFileController(AbstractController):
     def __init__(self, datafile: DataFile, dataset=None):
         super().__init__()
         self._datafile = datafile

--- a/dgp/core/controllers/datafile_controller.py
+++ b/dgp/core/controllers/datafile_controller.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
+from typing import cast, Generator
+
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QIcon
 
@@ -13,10 +15,9 @@ from dgp.core.models.datafile import DataFile
 
 
 class DataFileController(AbstractController):
-    def __init__(self, datafile: DataFile, dataset=None):
-        super().__init__()
-        self._datafile = datafile
-        self._dataset: IDataSetController = dataset
+
+    def __init__(self, datafile: DataFile, parent: IDataSetController = None):
+        super().__init__(model=datafile, parent=parent)
         self.log = logging.getLogger(__name__)
 
         self.set_datafile(datafile)
@@ -26,17 +27,18 @@ class DataFileController(AbstractController):
             ('addAction', (Icon.OPEN_FOLDER.icon(), 'Show in Explorer',
                            self._launch_explorer))
         ]
+        self.update()
 
     @property
     def uid(self) -> OID:
         try:
-            return self._datafile.uid
+            return super().uid
         except AttributeError:
             return None
 
     @property
-    def dataset(self) -> IDataSetController:
-        return self._dataset
+    def entity(self) -> DataFile:
+        return cast(DataFile, super().entity)
 
     @property
     def menu(self):  # pragma: no cover
@@ -44,14 +46,18 @@ class DataFileController(AbstractController):
 
     @property
     def group(self):
-        return self._datafile.group
+        return self.entity.group
 
-    @property
-    def datamodel(self) -> object:
-        return self._datafile
+    def clone(self):
+        raise NotImplementedError
+
+    def update(self):
+        super().update()
+        if self.entity is not None:
+            self.setText(self.entity.name)
 
     def set_datafile(self, datafile: DataFile):
-        self._datafile = datafile
+        self._model = datafile
         if datafile is None:
             self.setText("No Data")
             self.setToolTip("No Data")
@@ -60,18 +66,18 @@ class DataFileController(AbstractController):
             self.setText(datafile.label)
             self.setToolTip("Source path: {!s}".format(datafile.source_path))
             self.setData(datafile, role=Qt.UserRole)
-            if self._datafile.group is DataType.GRAVITY:
+            if self.entity.group is DataType.GRAVITY:
                 self.setIcon(Icon.GRAVITY.icon())
-            elif self._datafile.group is DataType.TRAJECTORY:
+            elif self.entity.group is DataType.TRAJECTORY:
                 self.setIcon(Icon.TRAJECTORY.icon())
 
     def _properties_dlg(self):
-        if self._datafile is None:
+        if self.entity is None:
             return
         # TODO: Launch dialog to show datafile properties (name, path, data etc)
-        data = HDF5Manager.load_data(self._datafile, self.dataset.hdfpath)
+        data = HDF5Manager.load_data(self.entity, self.get_parent().hdfpath)
         self.log.info(f'\n{data.describe()}')
 
     def _launch_explorer(self):
-        if self._datafile is not None:
-            show_in_explorer(self._datafile.source_path.parent)
+        if self.entity is not None:
+            show_in_explorer(self.entity.source_path.parent)

--- a/dgp/core/controllers/datafile_controller.py
+++ b/dgp/core/controllers/datafile_controller.py
@@ -33,6 +33,9 @@ class DataFileController(AbstractController):
     def uid(self) -> OID:
         try:
             return super().uid
+        # This can occur when no underlying datafile is set
+        # TODO: This behavior should change in future, a better way to handle
+        # empty/unset data files is needed
         except AttributeError:
             return None
 
@@ -71,13 +74,13 @@ class DataFileController(AbstractController):
             elif self.entity.group is DataType.TRAJECTORY:
                 self.setIcon(Icon.TRAJECTORY.icon())
 
-    def _properties_dlg(self):
+    def _properties_dlg(self):  # pragma: no cover
         if self.entity is None:
             return
         # TODO: Launch dialog to show datafile properties (name, path, data etc)
         data = HDF5Manager.load_data(self.entity, self.get_parent().hdfpath)
         self.log.info(f'\n{data.describe()}')
 
-    def _launch_explorer(self):
+    def _launch_explorer(self):  # pragma: no cover
         if self.entity is not None:
             show_in_explorer(self.entity.source_path.parent)

--- a/dgp/core/controllers/dataset_controller.py
+++ b/dgp/core/controllers/dataset_controller.py
@@ -42,7 +42,7 @@ class DataSegmentController(IBaseController):
         self.update()
 
         self._menu = [
-            ('addAction', ('Delete', lambda: self._delete()))
+            ('addAction', ('Delete', self.delete))
         ]
 
     @property
@@ -57,8 +57,8 @@ class DataSegmentController(IBaseController):
     def menu(self):
         return self._menu
 
-    def add_reference(self, group: LinearSegmentGroup):
-        self._refs.add(group)
+    def add_ref(self, ref):
+        self._refs.add(ref)
 
     def update(self):
         self.setText(str(self._segment))
@@ -67,7 +67,7 @@ class DataSegmentController(IBaseController):
     def clone(self) -> 'DataSegmentController':
         return DataSegmentController(self._segment, clone=True)
 
-    def _delete(self):
+    def delete(self):
         """Delete this data segment from any active plots (via weak ref), and
         from its parent DataSet/Controller
 
@@ -145,6 +145,10 @@ class DataSetController(IDataSetController):
     @property
     def project(self) -> IAirborneController:
         return self._flight.get_parent()
+
+    @property
+    def is_active(self):
+        return False
 
     @property
     def hdfpath(self) -> Path:
@@ -299,17 +303,6 @@ class DataSetController(IDataSetController):
     def update(self):
         self.setText(self._dataset.name)
         super().update()
-
-    def set_active(self, state: bool):
-        self._active = bool(state)
-        if self._active:
-            self.setBackground(QColor(StateColor.ACTIVE.value))
-        else:
-            self.setBackground(QColor(StateColor.INACTIVE.value))
-
-    @property
-    def is_active(self) -> bool:
-        return self._active
 
     # Context Menu Handlers
     def _set_name(self):

--- a/dgp/core/controllers/dataset_controller.py
+++ b/dgp/core/controllers/dataset_controller.py
@@ -38,6 +38,7 @@ class DataSegmentController(AbstractController):
 
         self._menu = [
             ('addAction', ('Delete', self._action_delete)),
+            ('addAction', ('Properties', self._action_properties))
         ]
 
     @property
@@ -61,6 +62,8 @@ class DataSegmentController(AbstractController):
         self.setText(str(self.entity))
         self.setToolTip(repr(self.entity))
 
+    def _action_properties(self):
+        pass
 
 
 class DataSetController(IDataSetController):
@@ -109,7 +112,7 @@ class DataSetController(IDataSetController):
             ('addAction', ('Align Data', self.align)),
             ('addSeparator', ()),
             ('addAction', ('Delete', self._action_delete)),
-            ('addAction', ('Properties', lambda: None))
+            ('addAction', ('Properties', self._action_properties))
         ]
 
         self._clones: Set[DataSetController] = weakref.WeakSet()
@@ -274,3 +277,6 @@ class DataSetController(IDataSetController):
 
     def _action_delete(self, confirm: bool = True):
         self.get_parent().remove_child(self.uid, confirm)
+
+    def _action_properties(self):
+        pass

--- a/dgp/core/controllers/dataset_controller.py
+++ b/dgp/core/controllers/dataset_controller.py
@@ -212,11 +212,11 @@ class DataSetController(IDataSetController):
 
     def add_datafile(self, datafile: DataFile) -> None:
         if datafile.group is DataType.GRAVITY:
-            self.datamodel.gravity = datafile
+            self.entity.gravity = datafile
             self._grav_file.set_datafile(datafile)
             self._gravity = DataFrame()
         elif datafile.group is DataType.TRAJECTORY:
-            self.datamodel.trajectory = datafile
+            self.entity.trajectory = datafile
             self._traj_file.set_datafile(datafile)
             self._trajectory = DataFrame()
         else:

--- a/dgp/core/controllers/dataset_controller.py
+++ b/dgp/core/controllers/dataset_controller.py
@@ -39,7 +39,7 @@ class DataSegmentController(AbstractController):
         self.update()
 
         self._menu = [
-            ('addAction', ('Delete', self.delete))
+            ('addAction', ('Delete', self._action_delete)),
         ]
 
     @property
@@ -60,18 +60,13 @@ class DataSegmentController(AbstractController):
         self.setToolTip(repr(self._segment))
 
     def clone(self) -> 'DataSegmentController':
-        return DataSegmentController(self._segment, clone=True)
+        clone = DataSegmentController(self.entity)
+        self.register_clone(clone)
+        return clone
 
-    def delete(self):
-        """Delete this data segment from any active plots (via weak ref), and
-        from its parent DataSet/Controller
+    def _action_delete(self):
+        self.get_parent().remove_child(self.uid, confirm=True)
 
-        """
-        super().delete()
-        try:
-            self._parent.remove_segment(self.uid)
-        except KeyError:
-            pass
 
 
 class DataSetController(IDataSetController):
@@ -136,7 +131,9 @@ class DataSetController(IDataSetController):
         return None
 
     def clone(self):
-        return DataSetController(self._dataset, self.get_parent())
+        clone = DataSetController(self.entity, self.get_parent(), self.project)
+        self.register_clone(clone)
+        return clone
 
     @property
     def project(self):

--- a/dgp/core/controllers/dataset_controller.py
+++ b/dgp/core/controllers/dataset_controller.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+import warnings
 import weakref
 from pathlib import Path
 from typing import List, Union, Set, cast
@@ -64,7 +65,7 @@ class DataSegmentController(AbstractController):
         self.setToolTip(repr(self.entity))
 
     def _action_properties(self):
-        pass
+        warnings.warn("Properties feature not yet implemented")
 
 
 class DataSetController(IDataSetController):
@@ -141,7 +142,7 @@ class DataSetController(IDataSetController):
         return self._channel_model
 
     @property
-    def segment_model(self) -> QStandardItemModel:
+    def segment_model(self) -> QStandardItemModel:  # pragma: no cover
         return self._segments.internal_model
 
     @property
@@ -187,7 +188,10 @@ class DataSetController(IDataSetController):
             self._dataframe: DataFrame = concat([self.gravity, self.trajectory], axis=1, sort=True)
         return self._dataframe
 
-    def align(self):
+    def align(self):  # pragma: no cover
+        """
+        TODO: Utility of this is questionable, is it built into transform graphs?
+        """
         if self.gravity.empty or self.trajectory.empty:
             _log.info(f'Gravity or Trajectory is empty, cannot align.')
             return
@@ -251,14 +255,14 @@ class DataSetController(IDataSetController):
         super().update()
 
     # Context Menu Handlers
-    def _action_set_name(self):
+    def _action_set_name(self):  # pragma: no cover
         name = controller_helpers.get_input("Set DataSet Name", "Enter a new name:",
                                             self.get_attr('name'),
                                             parent=self.parent_widget)
         if name:
             self.set_attr('name', name)
 
-    def _action_set_sensor_dlg(self):
+    def _action_set_sensor_dlg(self):  # pragma: no cover
         sensors = {}
         for i in range(self.project.meter_model.rowCount()):
             sensor = self.project.meter_model.item(i)
@@ -275,8 +279,8 @@ class DataSetController(IDataSetController):
             self._sensor: GravimeterController = sensor.clone()
             self.appendRow(self._sensor)
 
-    def _action_delete(self, confirm: bool = True):
+    def _action_delete(self, confirm: bool = True):  # pragma: no cover
         self.get_parent().remove_child(self.uid, confirm)
 
-    def _action_properties(self):
-        pass
+    def _action_properties(self):  # pragma: no cover
+        warnings.warn("Properties action not yet implemented")

--- a/dgp/core/controllers/dataset_controller.py
+++ b/dgp/core/controllers/dataset_controller.py
@@ -20,14 +20,14 @@ from dgp.gui.plotting.helpers import LineUpdate
 
 from . import controller_helpers
 from .gravimeter_controller import GravimeterController
-from .controller_interfaces import IFlightController, IDataSetController, AbstractController
+from .controller_interfaces import IFlightController, IDataSetController, VirtualBaseController
 from .project_containers import ProjectFolder
 from .datafile_controller import DataFileController
 
 _log = logging.getLogger(__name__)
 
 
-class DataSegmentController(AbstractController):
+class DataSegmentController(VirtualBaseController):
     """Controller for :class:`DataSegment`
 
     Implements reference tracking feature allowing the mutation of segments

--- a/dgp/core/controllers/flight_controller.py
+++ b/dgp/core/controllers/flight_controller.py
@@ -29,7 +29,7 @@ class FlightController(IFlightController):
     The default display behavior is to provide the Flights Name.
     A :obj:`QIcon` or string path to a resource can be provided for decoration.
 
-    FlightController implements the AttributeProxy mixin (via AbstractController),
+    FlightController implements the AttributeProxy mixin (via VirtualBaseController),
     which allows access to the underlying :class:`Flight` attributes via the
     get_attr and set_attr methods.
 

--- a/dgp/core/controllers/flight_controller.py
+++ b/dgp/core/controllers/flight_controller.py
@@ -68,11 +68,9 @@ class FlightController(IFlightController):
             ('addAction', ('Import Trajectory',
                            lambda: self._load_file_dialog(DataType.TRAJECTORY))),
             ('addSeparator', ()),
-            ('addAction', (f'Delete {self.entity.name}',
-                           lambda: self._delete_self(confirm=True))),
-            ('addAction', ('Rename Flight', lambda: self._set_name())),
-            ('addAction', ('Properties',
-                           lambda: self._show_properties_dlg()))
+            ('addAction', (f'Delete {self.entity.name}', self._action_delete_self)),
+            ('addAction', ('Rename Flight', self._set_name)),
+            ('addAction', ('Properties', self._show_properties_dlg))
         ]
         self.update()
 
@@ -185,7 +183,7 @@ class FlightController(IFlightController):
     def _add_dataset(self):
         self.add_child(DataSet(name=f'DataSet-{self.datasets.rowCount()}'))
 
-    def _delete_self(self, confirm: bool = True):
+    def _action_delete_self(self, confirm: bool = True):
         self.get_parent().remove_child(self.uid, confirm)
 
     def _set_name(self):  # pragma: no cover

--- a/dgp/core/controllers/flight_controller.py
+++ b/dgp/core/controllers/flight_controller.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
-from weakref import WeakSet
-from typing import Union
+import weakref
+from typing import Union, Generator
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QStandardItemModel, QColor
@@ -58,7 +58,7 @@ class FlightController(IFlightController):
         self.setEditable(False)
         self.setBackground(QColor(StateColor.INACTIVE.value))
 
-        self._clones = WeakSet()
+        self._clones = weakref.WeakSet()
         self._dataset_model = QStandardItemModel()
 
         for dataset in self._flight.datasets:
@@ -131,32 +131,6 @@ class FlightController(IFlightController):
         self._clones.add(clone)
         return clone
 
-    @property
-    def is_active(self):
-        return self._active
-
-    def set_active(self, state: bool):
-        self._active = bool(state)
-        if self._active:
-            self.setBackground(QColor(StateColor.ACTIVE.value))
-        else:
-            self.setBackground(QColor(StateColor.INACTIVE.value))
-
-    @property
-    def active_child(self) -> DataSetController:
-        """active_child overrides method in IParent
-
-        If no child is active, try to activate the first child (row 0) and
-        return the newly active child.
-        If the flight has no children None will be returned
-
-        """
-        child = super().active_child
-        if child is None and self.rowCount():
-            self.activate_child(self.child(0).uid)
-            return self.active_child
-        return child
-
     def add_child(self, child: DataSet) -> DataSetController:
         """Adds a child to the underlying Flight, and to the model representation
         for the appropriate child type.
@@ -222,6 +196,7 @@ class FlightController(IFlightController):
                                           self.parent_widget):
                 return False
 
+        child.delete()
         self._flight.datasets.remove(child.datamodel)
         self._dataset_model.removeRow(child.row())
         self.removeRow(child.row())

--- a/dgp/core/controllers/flight_controller.py
+++ b/dgp/core/controllers/flight_controller.py
@@ -51,7 +51,7 @@ class FlightController(IFlightController):
         self._dataset_model = QStandardItemModel()
 
         for dataset in self.entity.datasets:
-            control = DataSetController(dataset, self, project)
+            control = DataSetController(dataset, project, self)
             self.appendRow(control)
             self._dataset_model.appendRow(control.clone())
 
@@ -97,7 +97,7 @@ class FlightController(IFlightController):
         super().update()
 
     def clone(self):
-        clone = FlightController(self.entity, project=self.get_parent())
+        clone = FlightController(self.entity, self.project)
         self.register_clone(clone)
         return clone
 
@@ -126,7 +126,7 @@ class FlightController(IFlightController):
                             f'FlightController, must be {type(DataSet)}')
 
         self.entity.datasets.append(child)
-        control = DataSetController(child, self, project=self.project)
+        control = DataSetController(child, self.project, self)
         self.appendRow(control)
         self._dataset_model.appendRow(control.clone())
         self.update()

--- a/dgp/core/controllers/flight_controller.py
+++ b/dgp/core/controllers/flight_controller.py
@@ -120,8 +120,8 @@ class FlightController(IFlightController):
         super().update()
 
     def clone(self):
-        clone = FlightController(self._flight, project=self.get_parent())
-        self._clones.add(clone)
+        clone = FlightController(self.entity, project=self.get_parent())
+        self.register_clone(clone)
         return clone
 
     def delete(self):

--- a/dgp/core/controllers/gravimeter_controller.py
+++ b/dgp/core/controllers/gravimeter_controller.py
@@ -9,8 +9,8 @@ from dgp.core.models.meter import Gravimeter
 
 class GravimeterController(IMeterController):
 
-    def __init__(self, meter: Gravimeter, parent: IAirborneController = None):
-        super().__init__(model=meter, parent=parent)
+    def __init__(self, meter: Gravimeter, project, parent: IAirborneController = None):
+        super().__init__(meter, project, parent=parent)
         self.setIcon(Icon.METER.icon())
 
         self._bindings = [
@@ -28,7 +28,7 @@ class GravimeterController(IMeterController):
         return self._bindings
 
     def clone(self):
-        clone = GravimeterController(self.entity, self.get_parent())
+        clone = GravimeterController(self.entity, self.project)
         self.register_clone(clone)
         return clone
 

--- a/dgp/core/controllers/gravimeter_controller.py
+++ b/dgp/core/controllers/gravimeter_controller.py
@@ -42,6 +42,10 @@ class GravimeterController(IMeterController):
 
     def set_parent(self, parent: IAirborneController) -> None:
         self._parent = parent
+    def clone(self):
+        clone = GravimeterController(self.entity, self.get_parent())
+        self.register_clone(clone)
+        return clone
 
     def update(self):
         self.setData(self._meter.name, Qt.DisplayRole)

--- a/dgp/core/controllers/gravimeter_controller.py
+++ b/dgp/core/controllers/gravimeter_controller.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-from PyQt5.QtCore import Qt
+from typing import cast
 
 from dgp.core import Icon
-from dgp.core.oid import OID
 from dgp.core.controllers.controller_interfaces import IAirborneController, IMeterController
 from dgp.core.controllers.controller_helpers import get_input
 from dgp.core.models.meter import Gravimeter
@@ -11,53 +10,35 @@ from dgp.core.models.meter import Gravimeter
 class GravimeterController(IMeterController):
 
     def __init__(self, meter: Gravimeter, parent: IAirborneController = None):
-        super().__init__(meter.name)
-        self.setEditable(False)
-        self.setData(meter, role=Qt.UserRole)
+        super().__init__(model=meter, parent=parent)
         self.setIcon(Icon.METER.icon())
 
-        self._meter = meter  # type: Gravimeter
-        self._parent = parent
-
         self._bindings = [
-            ('addAction', ('Delete <%s>' % self._meter.name,
+            ('addAction', ('Delete <%s>' % self.entity.name,
                            (lambda: self.get_parent().remove_child(self.uid, True)))),
             ('addAction', ('Rename', self.set_name_dlg))
         ]
 
     @property
-    def uid(self) -> OID:
-        return self._meter.uid
-
-    @property
-    def datamodel(self) -> object:
-        return self._meter
+    def entity(self) -> Gravimeter:
+        return cast(Gravimeter, super().entity)
 
     @property
     def menu(self):
         return self._bindings
 
-    def get_parent(self) -> IAirborneController:
-        return self._parent
-
-    def set_parent(self, parent: IAirborneController) -> None:
-        self._parent = parent
     def clone(self):
         clone = GravimeterController(self.entity, self.get_parent())
         self.register_clone(clone)
         return clone
 
     def update(self):
-        self.setData(self._meter.name, Qt.DisplayRole)
+        self.setText(self.entity.name)
+        super().update()
 
     def set_name_dlg(self):  # pragma: no cover
-        name = get_input("Set Name", "Enter a new name:", self._meter.name,
+        name = get_input("Set Name", "Enter a new name:", self.entity.name,
                          self.parent_widget)
         if name:
             self.set_attr('name', name)
 
-    def clone(self):
-        return GravimeterController(self._meter, self.get_parent())
-
-    def __hash__(self):
-        return hash(self._meter.uid)

--- a/dgp/core/controllers/project_controllers.py
+++ b/dgp/core/controllers/project_controllers.py
@@ -2,7 +2,6 @@
 import functools
 import itertools
 import logging
-import weakref
 from pathlib import Path
 from typing import Union, List, Generator, cast
 
@@ -46,19 +45,15 @@ class AirborneProjectController(IAirborneController):
 
     """
     def __init__(self, project: AirborneProject, path: Path = None):
-        super().__init__(project.name)
+        super().__init__(model=project)
         self.log = logging.getLogger(__name__)
-        self._project = project
         if path:
-            self._project.path = path
+            self.entity.path = path
 
-        self._parent = None
         self._active = None
 
         self.setIcon(Icon.DGP_NOTEXT.icon())
-        self.setToolTip(str(self._project.path.resolve()))
-        self.setData(project, Qt.UserRole)
-        self.setBackground(QColor(StateColor.INACTIVE.value))
+        self.setToolTip(str(self.entity.path.resolve()))
 
         self.flights = ProjectFolder("Flights")
         self.appendRow(self.flights)
@@ -70,11 +65,11 @@ class AirborneProjectController(IAirborneController):
 
         # It is important that GravimeterControllers are defined before Flights
         # Flights may create references to a Gravimeter object, but not vice versa
-        for meter in self.project.gravimeters:
+        for meter in self.entity.gravimeters:
             controller = GravimeterController(meter, parent=self)
             self.meters.appendRow(controller)
 
-        for flight in self.project.flights:
+        for flight in self.entity.flights:
             controller = FlightController(flight, project=self)
             self.flights.appendRow(controller)
 
@@ -98,7 +93,6 @@ class AirborneProjectController(IAirborneController):
             'modify_date': (False, None)
         }
 
-
     def validator(self, key: str):  # pragma: no cover
         if key in self._fields:
             return self._fields[key][1]
@@ -108,6 +102,14 @@ class AirborneProjectController(IAirborneController):
         if key in self._fields:
             return self._fields[key][0]
         return True
+
+    @property
+    def entity(self) -> AirborneProject:
+        return cast(AirborneProject, super().entity)
+
+    @property
+    def menu(self):  # pragma: no cover
+        return self._bindings
 
     def clone(self):
         raise NotImplementedError
@@ -123,28 +125,12 @@ class AirborneProjectController(IAirborneController):
         return list(self._fields.keys())
 
     @property
-    def uid(self) -> OID:
-        return self._project.uid
-
-    @property
-    def datamodel(self) -> object:
-        return self._project
-
-    @property
-    def project(self) -> Union[GravityProject, AirborneProject]:
-        return self._project
-
-    @property
     def path(self) -> Path:
-        return self._project.path
-
-    @property
-    def menu(self):  # pragma: no cover
-        return self._bindings
+        return self.entity.path
 
     @property
     def hdfpath(self) -> Path:
-        return self._project.path.joinpath("dgpdata.hdf5")
+        return self.entity.path.joinpath("dgpdata.hdf5")
 
     @property
     def meter_model(self) -> QStandardItemModel:
@@ -163,11 +149,11 @@ class AirborneProjectController(IAirborneController):
             self.meters.appendRow(controller)
         else:
             raise ValueError("{0!r} is not a valid child type for {1.__name__}".format(child, self.__class__))
-        self.project.add_child(child)
+        self.entity.add_child(child)
         self.update()
         return controller
 
-    def remove_child(self, uid: Union[OID, str], confirm: bool = True):
+    def remove_child(self, uid: OID, confirm: bool = True):
         child = self.get_child(uid)
         if child is None:
             self.log.warning(f'UID {uid!s} has no corresponding object in this '
@@ -181,8 +167,8 @@ class AirborneProjectController(IAirborneController):
                 return
 
         child.delete()
-        self.project.remove_child(child.uid)
-        self._child_map[child.datamodel.__class__].removeRow(child.row())
+        self.entity.remove_child(child.uid)
+        self._child_map[child.entity.__class__].removeRow(child.row())
         self.update()
 
     def get_parent(self) -> ProjectTreeModel:
@@ -204,11 +190,11 @@ class AirborneProjectController(IAirborneController):
         return self._active
 
     def save(self, to_file=True):
-        return self.project.to_json(indent=2, to_file=to_file)
+        return self.entity.to_json(indent=2, to_file=to_file)
 
     def set_name(self):  # pragma: no cover
         new_name = get_input("Set Project Name", "Enter a Project Name",
-                             self.project.name, parent=self.parent_widget)
+                             self.entity.name, parent=self.parent_widget)
         if new_name:
             self.set_attr('name', new_name)
 
@@ -224,7 +210,7 @@ class AirborneProjectController(IAirborneController):
     def update(self):  # pragma: no cover
         """Emit an update event from the parent Model, signalling that
         data has been added/removed/modified in the project."""
-        self.setText(self._project.name)
+        self.setText(self.entity.name)
         try:
             self.get_parent().project_mutated(self)
         except AttributeError:

--- a/dgp/core/controllers/project_controllers.py
+++ b/dgp/core/controllers/project_controllers.py
@@ -45,7 +45,7 @@ class AirborneProjectController(IAirborneController):
 
     """
     def __init__(self, project: AirborneProject, path: Path = None):
-        super().__init__(model=project)
+        super().__init__(project, self)
         self.log = logging.getLogger(__name__)
         if path:
             self.entity.path = path
@@ -66,7 +66,7 @@ class AirborneProjectController(IAirborneController):
         # It is important that GravimeterControllers are defined before Flights
         # Flights may create references to a Gravimeter object, but not vice versa
         for meter in self.entity.gravimeters:
-            controller = GravimeterController(meter, parent=self)
+            controller = GravimeterController(meter, self, parent=self)
             self.meters.appendRow(controller)
 
         for flight in self.entity.flights:
@@ -142,10 +142,10 @@ class AirborneProjectController(IAirborneController):
 
     def add_child(self, child: Union[Flight, Gravimeter]) -> Union[FlightController, GravimeterController]:
         if isinstance(child, Flight):
-            controller = FlightController(child, project=self)
+            controller = FlightController(child, self)
             self.flights.appendRow(controller)
         elif isinstance(child, Gravimeter):
-            controller = GravimeterController(child, parent=self)
+            controller = GravimeterController(child, self, parent=self)
             self.meters.appendRow(controller)
         else:
             raise ValueError("{0!r} is not a valid child type for {1.__name__}".format(child, self.__class__))

--- a/dgp/core/controllers/project_controllers.py
+++ b/dgp/core/controllers/project_controllers.py
@@ -109,6 +109,9 @@ class AirborneProjectController(IAirborneController):
             return self._fields[key][0]
         return True
 
+    def clone(self):
+        raise NotImplementedError
+
     @property
     def children(self) -> Generator[IFlightController, None, None]:
         for child in itertools.chain(self.flights.items(), self.meters.items()):
@@ -226,6 +229,7 @@ class AirborneProjectController(IAirborneController):
             self.get_parent().project_mutated(self)
         except AttributeError:
             self.log.warning(f"project {self.get_attr('name')} has no parent")
+        super().update()
 
     def _post_load(self, datafile: DataFile, dataset: IDataSetController,
                    data: DataFrame) -> None:  # pragma: no cover

--- a/dgp/core/controllers/project_treemodel.py
+++ b/dgp/core/controllers/project_treemodel.py
@@ -9,7 +9,7 @@ from dgp.core import OID, DataType
 from dgp.core.controllers.controller_interfaces import (IFlightController,
                                                         IAirborneController,
                                                         IDataSetController,
-                                                        AbstractController)
+                                                        VirtualBaseController)
 from dgp.core.controllers.controller_helpers import confirm_action
 from dgp.gui.utils import ProgressEvent
 
@@ -107,7 +107,7 @@ class ProjectTreeModel(QStandardItemModel):
         """Double-click handler for View events"""
 
         item = self.itemFromIndex(index)
-        if not isinstance(item, AbstractController):
+        if not isinstance(item, VirtualBaseController):
             return
 
         if isinstance(item, IAirborneController):

--- a/dgp/core/controllers/project_treemodel.py
+++ b/dgp/core/controllers/project_treemodel.py
@@ -8,7 +8,8 @@ from PyQt5.QtGui import QStandardItemModel
 from dgp.core import OID, DataType
 from dgp.core.controllers.controller_interfaces import (IFlightController,
                                                         IAirborneController,
-                                                        IDataSetController, AbstractController)
+                                                        IDataSetController,
+                                                        AbstractController)
 from dgp.core.controllers.controller_helpers import confirm_action
 from dgp.gui.utils import ProgressEvent
 

--- a/dgp/core/controllers/project_treemodel.py
+++ b/dgp/core/controllers/project_treemodel.py
@@ -36,10 +36,6 @@ class ProjectTreeModel(QStandardItemModel):
         Signal emitted to notify application that project data has changed.
     tabOpenRequested : pyqtSignal[IFlightController]
         Signal emitted to request a tab be opened for the supplied Flight
-    tabCloseRequested : pyqtSignal(IFlightController)
-        Signal notifying application that tab for given flight should be closed
-        This is called for example when a Flight is deleted to ensure any open
-        tabs referencing it are also deleted.
     progressNotificationRequested : pyqtSignal[ProgressEvent]
         Signal emitted to request a QProgressDialog from the main window.
         ProgressEvent is passed defining the parameters for the progress bar
@@ -49,7 +45,6 @@ class ProjectTreeModel(QStandardItemModel):
     projectMutated = pyqtSignal()
     projectClosed = pyqtSignal(OID)
     tabOpenRequested = pyqtSignal(object, object)
-    tabCloseRequested = pyqtSignal(OID)
     progressNotificationRequested = pyqtSignal(ProgressEvent)
     sigDataChanged = pyqtSignal(object)
 
@@ -98,15 +93,10 @@ class ProjectTreeModel(QStandardItemModel):
                                           f"{child.get_attr('name')}?",
                                           self.parent()):
             return
-        for i in range(child.flight_model.rowCount()):
-            flt: IFlightController = child.flight_model.item(i, 0)
-            self.tabCloseRequested.emit(flt.uid)
         child.save()
+        child.delete()
         self.removeRow(child.row())
         self.projectClosed.emit(child.uid)
-
-    def notify_tab_changed(self, flight: IFlightController):
-        flight.get_parent().activate_child(flight.uid)
 
     def item_selected(self, index: QModelIndex):
         """Single-click handler for View events"""

--- a/dgp/core/controllers/project_treemodel.py
+++ b/dgp/core/controllers/project_treemodel.py
@@ -17,6 +17,13 @@ __all__ = ['ProjectTreeModel']
 
 
 class ProjectTreeModel(QStandardItemModel):
+    activeProjectChanged = pyqtSignal(str)
+    projectMutated = pyqtSignal()
+    projectClosed = pyqtSignal(OID)
+    tabOpenRequested = pyqtSignal(object, object)
+    progressNotificationRequested = pyqtSignal(ProgressEvent)
+    sigDataChanged = pyqtSignal(object)
+
     """Extension of QStandardItemModel which handles Project/Model specific
     events and defines signals for domain specific actions.
 
@@ -41,13 +48,6 @@ class ProjectTreeModel(QStandardItemModel):
         ProgressEvent is passed defining the parameters for the progress bar
 
     """
-    activeProjectChanged = pyqtSignal(str)
-    projectMutated = pyqtSignal()
-    projectClosed = pyqtSignal(OID)
-    tabOpenRequested = pyqtSignal(object, object)
-    progressNotificationRequested = pyqtSignal(ProgressEvent)
-    sigDataChanged = pyqtSignal(object)
-
     def __init__(self, project: IAirborneController = None,
                  parent: Optional[QObject] = None):
         super().__init__(parent)
@@ -87,7 +87,8 @@ class ProjectTreeModel(QStandardItemModel):
     def add_project(self, child: IAirborneController):
         self.appendRow(child)
 
-    def remove_project(self, child: IAirborneController, confirm: bool = True) -> None:
+    def remove_project(self, child: IAirborneController,
+                       confirm: bool = True) -> None:  # pragma: no cover
         if confirm and not confirm_action("Confirm Project Close",
                                           f"Close Project "
                                           f"{child.get_attr('name')}?",
@@ -147,5 +148,5 @@ class ProjectTreeModel(QStandardItemModel):
             return self._warn_no_active_project()
         self.active_project.add_flight_dlg()
 
-    def _warn_no_active_project(self):
+    def _warn_no_active_project(self):  # pragma: no cover
         self.log.warning("No active projects.")

--- a/dgp/gui/main.py
+++ b/dgp/gui/main.py
@@ -73,7 +73,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
 
         # Model Event Signals #
         self.model.tabOpenRequested.connect(self._tab_open_requested)
-        self.model.tabCloseRequested.connect(self.workspace.close_tab)
+        # self.model.tabCloseRequested.connect(self.workspace.close_tab)
         self.model.progressNotificationRequested.connect(self._progress_event_handler)
         self.model.projectMutated.connect(self._project_mutated)
         self.model.projectClosed.connect(lambda x: self._update_recent_menu())

--- a/dgp/gui/main.py
+++ b/dgp/gui/main.py
@@ -10,8 +10,8 @@ from PyQt5.QtWidgets import QProgressDialog, QFileDialog, QMessageBox, QMenu, QA
 
 from dgp import __about__
 from dgp.core.oid import OID
+from dgp.core.controllers.controller_interfaces import AbstractController
 from dgp.core.types.enumerations import Links, Icon
-from dgp.core.controllers.controller_interfaces import IBaseController
 from dgp.core.controllers.project_controllers import AirborneProjectController
 from dgp.core.controllers.project_treemodel import ProjectTreeModel
 from dgp.core.models.project import AirborneProject, GravityProject
@@ -260,7 +260,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         for ref in recents:
             self.recent_menu.addAction(ref.name, lambda: self.open_project(Path(ref.path)))
 
-    def _tab_open_requested(self, uid: OID, controller: IBaseController):
+    def _tab_open_requested(self, uid: OID, controller: AbstractController):
         """pyqtSlot(OID, IBaseController, str)
 
         Parameters

--- a/dgp/gui/main.py
+++ b/dgp/gui/main.py
@@ -10,7 +10,7 @@ from PyQt5.QtWidgets import QProgressDialog, QFileDialog, QMessageBox, QMenu, QA
 
 from dgp import __about__
 from dgp.core.oid import OID
-from dgp.core.controllers.controller_interfaces import AbstractController
+from dgp.core.controllers.controller_interfaces import VirtualBaseController
 from dgp.core.types.enumerations import Links, Icon
 from dgp.core.controllers.project_controllers import AirborneProjectController
 from dgp.core.controllers.project_treemodel import ProjectTreeModel
@@ -260,7 +260,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         for ref in recents:
             self.recent_menu.addAction(ref.name, lambda: self.open_project(Path(ref.path)))
 
-    def _tab_open_requested(self, uid: OID, controller: AbstractController):
+    def _tab_open_requested(self, uid: OID, controller: VirtualBaseController):
         """pyqtSlot(OID, IBaseController, str)
 
         Parameters

--- a/dgp/gui/plotting/helpers.py
+++ b/dgp/gui/plotting/helpers.py
@@ -174,7 +174,7 @@ class LinearSegment(LinearRegionItem):
         self.sigRegionChanged.connect(self._update_label_pos)
 
         self._menu = QMenu()
-        self._menu.addAction('Remove', lambda: self.sigDeleteRequested.emit())
+        self._menu.addAction('Remove', self.sigDeleteRequested.emit)
         self._menu.addAction('Set Label', self._get_label_dlg)
 
         plot.addItem(self)
@@ -332,11 +332,15 @@ class LinearSegmentGroup(QObject):
             segment.setVisible(visible)
             segment._label.setVisible(visible)
 
-    def delete(self):
+    def remove(self):
+        self.delete(emit=False)
+
+    def delete(self, emit=True):
         """Delete all child segments and emit a DELETE update"""
         for segment in self._segments:
             segment.remove()
-        self.emit_update(StateAction.DELETE)
+        if emit:
+            self.emit_update(StateAction.DELETE)
 
     def emit_update(self, action: StateAction = StateAction.UPDATE):
         """Emit a LineUpdate object with the current segment attributes
@@ -377,4 +381,3 @@ class LinearSegmentGroup(QObject):
         """Emit an update object when the rate-limit timer has expired"""
         self._timer.stop()
         self.emit_update(StateAction.UPDATE)
-

--- a/dgp/gui/views/project_tree_view.py
+++ b/dgp/gui/views/project_tree_view.py
@@ -7,8 +7,7 @@ from PyQt5.QtGui import QContextMenuEvent
 from PyQt5.QtWidgets import QTreeView, QMenu
 
 from dgp.core.controllers.controller_interfaces import (IAirborneController,
-                                                        IChild,
-                                                        IBaseController,
+                                                        AbstractController,
                                                         MenuBinding)
 from dgp.core.controllers.project_treemodel import ProjectTreeModel
 
@@ -68,7 +67,7 @@ class ProjectTreeView(QTreeView):
     def _on_double_click(self, index: QModelIndex):
         """Selectively expand/collapse an item depending on its active state"""
         item = self.model().itemFromIndex(index)
-        if isinstance(item, IChild):
+        if isinstance(item, AbstractController):
             if item.is_active:
                 self.setExpanded(index, not self.isExpanded(index))
             else:
@@ -86,12 +85,12 @@ class ProjectTreeView(QTreeView):
 
     def contextMenuEvent(self, event: QContextMenuEvent, *args, **kwargs):
         index = self.indexAt(event.pos())
-        item: IBaseController = self.model().itemFromIndex(index)
+        item: AbstractController = self.model().itemFromIndex(index)
         expanded = self.isExpanded(index)
 
         menu = QMenu(self)
         # bindings = getattr(item, 'menu_bindings', [])[:]  # type: List
-        if isinstance(item, IBaseController):
+        if isinstance(item, AbstractController):
             bindings = item.menu[:]
         else:
             bindings = []

--- a/dgp/gui/views/project_tree_view.py
+++ b/dgp/gui/views/project_tree_view.py
@@ -7,7 +7,7 @@ from PyQt5.QtGui import QContextMenuEvent
 from PyQt5.QtWidgets import QTreeView, QMenu
 
 from dgp.core.controllers.controller_interfaces import (IAirborneController,
-                                                        AbstractController,
+                                                        VirtualBaseController,
                                                         MenuBinding)
 from dgp.core.controllers.project_treemodel import ProjectTreeModel
 
@@ -67,7 +67,7 @@ class ProjectTreeView(QTreeView):
     def _on_double_click(self, index: QModelIndex):
         """Selectively expand/collapse an item depending on its active state"""
         item = self.model().itemFromIndex(index)
-        if isinstance(item, AbstractController):
+        if isinstance(item, VirtualBaseController):
             if item.is_active:
                 self.setExpanded(index, not self.isExpanded(index))
             else:
@@ -85,12 +85,12 @@ class ProjectTreeView(QTreeView):
 
     def contextMenuEvent(self, event: QContextMenuEvent, *args, **kwargs):
         index = self.indexAt(event.pos())
-        item: AbstractController = self.model().itemFromIndex(index)
+        item: VirtualBaseController = self.model().itemFromIndex(index)
         expanded = self.isExpanded(index)
 
         menu = QMenu(self)
         # bindings = getattr(item, 'menu_bindings', [])[:]  # type: List
-        if isinstance(item, AbstractController):
+        if isinstance(item, VirtualBaseController):
             bindings = item.menu[:]
         else:
             bindings = []

--- a/dgp/gui/widgets/channel_control_widgets.py
+++ b/dgp/gui/widgets/channel_control_widgets.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 import itertools
 from functools import partial
 from typing import List, Dict, Tuple
@@ -17,6 +18,7 @@ from dgp.core import Icon, OID
 from dgp.gui.plotting.backends import GridPlotWidget, Axis, LINE_COLORS
 
 __all__ = ['ChannelController', 'ChannelItem']
+_log = logging.getLogger(__name__)
 
 
 class ColorPicker(QLabel):
@@ -406,10 +408,14 @@ class ChannelController(QWidget):
     def _remove_series(self, item: ChannelItem):
         line = self._active[item.uid]
         self.plotter.remove_plotitem(line)
-        del self._indexes[item.uid]
+        try:
+            del self._indexes[item.uid]
+        except KeyError:
+            pass
 
     def _channels_cleared(self):
         """Respond to plot notification that all lines have been cleared"""
+        _log.debug("Plot channels cleared")
         for i in range(self._model.rowCount()):
             item: ChannelItem = self._model.item(i)
             item.set_visible(False, emit=False)

--- a/dgp/gui/widgets/workspace_widget.py
+++ b/dgp/gui/widgets/workspace_widget.py
@@ -78,6 +78,7 @@ class WorkspaceWidget(QtWidgets.QTabWidget):
         if label is None:
             label = tab.title
         super().addTab(tab, label)
+        tab.sigControllerUpdated.connect(lambda: self._update_name(tab))
         self.setCurrentWidget(tab)
 
     # Utility functions for referencing Tab widgets by OID
@@ -92,11 +93,15 @@ class WorkspaceWidget(QtWidgets.QTabWidget):
         for i in range(self.count()):
             if uid == self.widget(i).uid:
                 return i
+        return -1
 
     def close_tab_by_index(self, index: int):
+        print(f"closing tab at index {index}")
+        if index == -1:
+            return
         tab = self.widget(index)
-        tab.close()
         self.removeTab(index)
+        tab.close()
 
     def close_tab(self, uid: OID):
         tab = self.get_tab(uid)
@@ -105,3 +110,7 @@ class WorkspaceWidget(QtWidgets.QTabWidget):
         index = self.get_tab_index(uid)
         if index is not None:
             self.removeTab(index)
+
+    def _update_name(self, tab: WorkspaceTab):
+        index = self.indexOf(tab)
+        self.setTabText(index, tab.title)

--- a/dgp/gui/workspaces/__init__.py
+++ b/dgp/gui/workspaces/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from dgp.core.controllers.controller_interfaces import AbstractController
+from dgp.core.controllers.controller_interfaces import VirtualBaseController
 from .project import ProjectTab, AirborneProjectController
 from .flight import FlightTab, FlightController
 from .dataset import DataSetTab, DataSetController
@@ -15,6 +15,6 @@ _tabmap = {
 }
 
 
-def tab_factory(controller: AbstractController):
+def tab_factory(controller: VirtualBaseController):
     """Return the workspace tab constructor for the given controller type"""
     return _tabmap.get(controller.__class__, None)

--- a/dgp/gui/workspaces/__init__.py
+++ b/dgp/gui/workspaces/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from dgp.core.controllers.controller_interfaces import IBaseController
+from dgp.core.controllers.controller_interfaces import AbstractController
 from .project import ProjectTab, AirborneProjectController
 from .flight import FlightTab, FlightController
 from .dataset import DataSetTab, DataSetController
@@ -15,6 +15,6 @@ _tabmap = {
 }
 
 
-def tab_factory(controller: IBaseController):
+def tab_factory(controller: AbstractController):
     """Return the workspace tab constructor for the given controller type"""
     return _tabmap.get(controller.__class__, None)

--- a/dgp/gui/workspaces/base.py
+++ b/dgp/gui/workspaces/base.py
@@ -1,18 +1,23 @@
 # -*- coding: utf-8 -*-
 import json
+import logging
 import weakref
 
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import pyqtSignal, Qt
 from PyQt5.QtGui import QCloseEvent
 from PyQt5.QtWidgets import QWidget
 
-from dgp.core import OID
+from dgp.core import OID, StateAction
+from dgp.core.controllers.controller_interfaces import AbstractController
 from dgp.gui import settings
 
 __all__ = ['WorkspaceTab', 'SubTab']
+_log = logging.getLogger(__name__)
 
 
 class WorkspaceTab(QWidget):
+    sigControllerUpdated = pyqtSignal()
+
     def __init__(self, controller: AbstractController, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.setAttribute(Qt.WA_DeleteOnClose, True)
@@ -22,7 +27,8 @@ class WorkspaceTab(QWidget):
 
     @property
     def uid(self) -> OID:
-        raise NotImplementedError
+        return self.controller.uid
+
     @property
     def controller(self) -> AbstractController:
         return self._controller()
@@ -48,16 +54,38 @@ class WorkspaceTab(QWidget):
 
         Override this method to provide state handling for a WorkspaceTab
         """
+        _log.debug(f"Saving tab {self.__class__.__name__} ({self.uid}) state")
         _jsons = json.dumps(state)
         settings().setValue(self.state_key, _jsons)
 
+    def close(self):
+        # Note: this must be defined in order to provide a bound method for
+        super().close()
+
     def closeEvent(self, event: QCloseEvent):
         self.save_state()
+        self.setParent(None)
         event.accept()
+
+    def _slot_update(self):
+        self.sigControllerUpdated.emit()
+
+    def __del__(self):
+        _log.debug(f"Deleting {self.__class__.__name__}")
 
 
 class SubTab(QWidget):
     sigLoaded = pyqtSignal(object)
+
+    def __init__(self, control: AbstractController, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setAttribute(Qt.WA_DeleteOnClose, True)
+        control.register_observer(self, self.close, StateAction.DELETE)
+        self._control = weakref.ref(control)
+
+    @property
+    def control(self):
+        return self._control()
 
     def get_state(self):
         """Get a representation of the current state of the SubTab
@@ -90,3 +118,9 @@ class SubTab(QWidget):
 
         """
         pass
+
+    def close(self):
+        super().close()
+
+    def __del__(self):
+        _log.debug(f"Deleting {self.__class__.__name__}")

--- a/dgp/gui/workspaces/base.py
+++ b/dgp/gui/workspaces/base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import weakref
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtGui import QCloseEvent
@@ -12,9 +13,19 @@ __all__ = ['WorkspaceTab', 'SubTab']
 
 
 class WorkspaceTab(QWidget):
+    def __init__(self, controller: AbstractController, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setAttribute(Qt.WA_DeleteOnClose, True)
+        controller.register_observer(self, self.close, StateAction.DELETE)
+        controller.register_observer(self, self._slot_update, StateAction.UPDATE)
+        self._controller = weakref.ref(controller)
+
     @property
     def uid(self) -> OID:
         raise NotImplementedError
+    @property
+    def controller(self) -> AbstractController:
+        return self._controller()
 
     @property
     def title(self) -> str:

--- a/dgp/gui/workspaces/base.py
+++ b/dgp/gui/workspaces/base.py
@@ -8,7 +8,7 @@ from PyQt5.QtGui import QCloseEvent
 from PyQt5.QtWidgets import QWidget
 
 from dgp.core import OID, StateAction
-from dgp.core.controllers.controller_interfaces import AbstractController
+from dgp.core.controllers.controller_interfaces import VirtualBaseController
 from dgp.gui import settings
 
 __all__ = ['WorkspaceTab', 'SubTab']
@@ -18,7 +18,7 @@ _log = logging.getLogger(__name__)
 class WorkspaceTab(QWidget):
     sigControllerUpdated = pyqtSignal()
 
-    def __init__(self, controller: AbstractController, *args, **kwargs):
+    def __init__(self, controller: VirtualBaseController, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.setAttribute(Qt.WA_DeleteOnClose, True)
         controller.register_observer(self, self.close, StateAction.DELETE)
@@ -30,7 +30,7 @@ class WorkspaceTab(QWidget):
         return self.controller.uid
 
     @property
-    def controller(self) -> AbstractController:
+    def controller(self) -> VirtualBaseController:
         return self._controller()
 
     @property
@@ -77,7 +77,7 @@ class WorkspaceTab(QWidget):
 class SubTab(QWidget):
     sigLoaded = pyqtSignal(object)
 
-    def __init__(self, control: AbstractController, *args, **kwargs):
+    def __init__(self, control: VirtualBaseController, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.setAttribute(Qt.WA_DeleteOnClose, True)
         control.register_observer(self, self.close, StateAction.DELETE)

--- a/dgp/gui/workspaces/dataset.py
+++ b/dgp/gui/workspaces/dataset.py
@@ -130,9 +130,7 @@ class DataSetTab(WorkspaceTab):
     """Root workspace tab for DataSet controller manipulation"""
 
     def __init__(self, dataset: DataSetController, parent=None):
-        super().__init__(parent=parent, flags=Qt.Widget)
-        self.dataset = dataset
-
+        super().__init__(controller=dataset, parent=parent, flags=Qt.Widget)
         self.ws_settings: dict = self.get_state()
 
         layout = QtWidgets.QVBoxLayout(self)
@@ -151,12 +149,8 @@ class DataSetTab(WorkspaceTab):
 
     @property
     def title(self):
-        return f'{self.dataset.get_attr("name")} ' \
-               f'[{self.dataset.parent().get_attr("name")}]'
-
-    @property
-    def uid(self):
-        return self.dataset.uid
+        return f'{self.controller.get_attr("name")} ' \
+               f'[{self.controller.parent().get_attr("name")}]'
 
     def _tab_loaded(self, tab: SubTab):
         """Restore tab state after initial loading is complete"""
@@ -171,4 +165,3 @@ class DataSetTab(WorkspaceTab):
             state[tab.__class__.__name__] = tab.get_state()
 
         super().save_state(state=state)
-

--- a/dgp/gui/workspaces/flight.py
+++ b/dgp/gui/workspaces/flight.py
@@ -1,16 +1,18 @@
 # -*- coding: utf-8 -*-
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QWidget
 
 from dgp.core.controllers.flight_controller import FlightController
-from .base import WorkspaceTab
+from .base import WorkspaceTab, SubTab
 
 
-class FlightMapTab(QWidget):
-    def __init__(self, flight, parent=None):
-        super().__init__(parent=parent, flags=Qt.Widget)
-        self.flight = flight
+class FlightMapTab(SubTab):
+    def __init__(self, flight: FlightController, parent=None):
+        super().__init__(flight, parent=parent, flags=Qt.Widget)
+
+    @property
+    def control(self) -> FlightController:
+        return super().control
 
 
 class FlightTab(WorkspaceTab):

--- a/dgp/gui/workspaces/flight.py
+++ b/dgp/gui/workspaces/flight.py
@@ -15,18 +15,13 @@ class FlightMapTab(QWidget):
 
 class FlightTab(WorkspaceTab):
     def __init__(self, flight: FlightController, parent=None):
-        super().__init__(parent=parent, flags=Qt.Widget)
-        self.flight = flight
+        super().__init__(flight, parent=parent, flags=Qt.Widget)
         layout = QtWidgets.QHBoxLayout(self)
         self.workspace = QtWidgets.QTabWidget()
-        self.workspace.addTab(FlightMapTab(self.flight), "Flight Map")
+        self.workspace.addTab(FlightMapTab(flight), "Flight Map")
 
         layout.addWidget(self.workspace)
 
     @property
     def title(self):
-        return f'{self.flight.get_attr("name")}'
-
-    @property
-    def uid(self):
-        return self.flight.uid
+        return f'{self.controller.get_attr("name")}'

--- a/docs/source/core/controllers.rst
+++ b/docs/source/core/controllers.rst
@@ -22,15 +22,18 @@ TODO: Add Controller Hierarchy like in models.rst
 Controller Development Principles
 ---------------------------------
 
-Controllers typically should match 1:1 a model class, though there are cases
-for creating utility controllers such as the :class:`ProjectFolder` which is
-a utility class for grouping items visually in the project's tree view.
+.. py:currentmodule:: dgp.core.controllers
 
-Controllers should at minimum subclass :class:`AbstractController` which configures
-inheritance for :class:`QStandardItem` and :class:`AttributeProxy`. For more
-complex and widely used controllers, a dedicated interface should be created
-following the same naming scheme - particularly where circular dependencies
-may be introduced.
+Controllers typically should match 1:1 a model class, though there are cases
+for creating controllers such as the :class:`~.project_containers.ProjectFolder`
+which is a utility class for grouping items visually in the project's tree view.
+
+Controllers should at minimum subclass
+:class:`~.controller_interfaces.AbstractController` which configures inheritance
+for :class:`QStandardItem` and :class:`~.controller_mixins.AttributeProxy`.
+For more complex and widely used controllers, a dedicated interface should be
+created following the same naming scheme - particularly where circular
+dependencies may be introduced.
 
 
 Context Menu Declarations
@@ -74,7 +77,6 @@ In most cases the concrete subclasses of these interfaces cannot be
 directly imported into other controllers as this would cause circular
 import loops
 
-.. py:module:: dgp.core.controllers
 
 e.g. the :class:`~.flight_controller.FlightController`
 is a child of an :class:`~.project_controllers.AirborneProjectController`,
@@ -101,15 +103,15 @@ type hinting within the development environment in such cases.
     :show-inheritance:
     :undoc-members:
 
-.. autoclass:: IParent
-    :undoc-members:
-
-.. autoclass:: IChild
+.. autoclass:: IDataSetController
+    :show-inheritance:
     :undoc-members:
 
 
 Controllers
 -----------
+
+**Concrete controller implementations**
 
 .. py:module:: dgp.core.controllers.project_controllers
 .. autoclass:: AirborneProjectController
@@ -135,6 +137,15 @@ Controllers
 .. autoclass:: DataFileController
     :undoc-members:
     :show-inheritance:
+
+Containers
+----------
+
+.. py:module:: dgp.core.controllers.project_containers
+.. autoclass:: ProjectFolder
+    :undoc-members:
+    :show-inheritance:
+
 
 Utility/Helper Modules
 ----------------------

--- a/docs/source/core/controllers.rst
+++ b/docs/source/core/controllers.rst
@@ -29,7 +29,7 @@ for creating controllers such as the :class:`~.project_containers.ProjectFolder`
 which is a utility class for grouping items visually in the project's tree view.
 
 Controllers should at minimum subclass
-:class:`~.controller_interfaces.AbstractController` which configures inheritance
+:class:`~.controller_interfaces.VirtualBaseController` which configures inheritance
 for :class:`QStandardItem` and :class:`~.controller_mixins.AttributeProxy`.
 For more complex and widely used controllers, a dedicated interface should be
 created following the same naming scheme - particularly where circular
@@ -87,7 +87,7 @@ type hinting within the development environment in such cases.
 
 .. py:module:: dgp.core.controllers.controller_interfaces
 
-.. autoclass:: AbstractController
+.. autoclass:: VirtualBaseController
     :show-inheritance:
     :undoc-members:
 

--- a/docs/source/core/controllers.rst
+++ b/docs/source/core/controllers.rst
@@ -26,7 +26,7 @@ Controllers typically should match 1:1 a model class, though there are cases
 for creating utility controllers such as the :class:`ProjectFolder` which is
 a utility class for grouping items visually in the project's tree view.
 
-Controllers should at minimum subclass :class:`IBaseController` which configures
+Controllers should at minimum subclass :class:`AbstractController` which configures
 inheritance for :class:`QStandardItem` and :class:`AttributeProxy`. For more
 complex and widely used controllers, a dedicated interface should be created
 following the same naming scheme - particularly where circular dependencies
@@ -85,7 +85,7 @@ type hinting within the development environment in such cases.
 
 .. py:module:: dgp.core.controllers.controller_interfaces
 
-.. autoclass:: IBaseController
+.. autoclass:: AbstractController
     :show-inheritance:
     :undoc-members:
 

--- a/docs/source/gui/index.rst
+++ b/docs/source/gui/index.rst
@@ -15,15 +15,16 @@ files, which are then compiled into a Python source files which define
 individual UI components.
 The .ui source files are contained within the ui directory.
 
-.. seealso::
-
-    `Qt 5 Documentation <http://doc.qt.io>`__
-
-    `PyQt5 Documentation <http://pyqt.sourceforge.net/Docs/PyQt5/>`__
-
-
 .. toctree::
     :caption: Sub Packages
     :maxdepth: 1
 
     plotting.rst
+    workspaces.rst
+
+
+.. seealso::
+
+    `Qt 5 Documentation <http://doc.qt.io>`__
+
+    `PyQt5 Documentation <http://pyqt.sourceforge.net/Docs/PyQt5/>`__

--- a/docs/source/gui/workspaces.rst
+++ b/docs/source/gui/workspaces.rst
@@ -1,0 +1,82 @@
+dgp.gui.workspaces package
+==========================
+
+
+The Workspaces sub-package defines GUI widgets for various controller
+contexts in the DGP application.
+The idea being that there are naturally different standard ways in which the
+user will interact with different project objects/controllers, depending on the
+type of the object.
+
+The workspaces are intended to be displayed within a QTabWidget within the
+application so that the user may easily navigate between multiple open
+workspaces.
+
+Each workspace defines its own custom widget(s) for interacting & manipulating
+data associated with its underlying controller (:class:`AbstractController`).
+
+Workspaces may also contain sub-tabs, for example the :class:`DataSetTab`
+defines sub-tabs for viewing raw-data and selecting segments, and a tab for
+executing transform graphs on the data.
+
+.. contents::
+    :depth: 3
+
+
+Base Interfaces
+---------------
+
+.. versionadded:: 0.1.0
+
+.. automodule:: dgp.gui.workspaces.base
+
+
+Workspaces
+----------
+
+Project Workspace
+^^^^^^^^^^^^^^^^^
+
+.. warning:: Not yet implemented
+
+.. note::
+
+    Future Planning: Project Workspace may display a map interface which can
+    overlay each flight's trajectory path from the flights within the project.
+    Some interface to allow comparison of flight data may also be integrated into
+    this workspace.
+
+.. automodule:: dgp.gui.workspaces.project
+
+Flight Workspace
+^^^^^^^^^^^^^^^^
+.. warning:: Not yet implemented
+
+.. note::
+
+    Future Planning: Similar to the project workspace, the flight workspace may
+    be used to display a map of the selected flight.
+    A dashboard type widget may be implemented to show details of the flight,
+    and to allow users to view/configure flight specific parameters.
+
+.. automodule:: dgp.gui.workspaces.flight
+
+
+DataSet Workspace
+^^^^^^^^^^^^^^^^^
+.. versionadded:: 0.1.0
+
+.. automodule:: dgp.gui.workspaces.dataset
+
+
+
+DataFile Workspace
+^^^^^^^^^^^^^^^^^^
+.. warning:: Not yet implemented
+
+.. note::
+
+    Future Planning: The DataFile workspace may be used to allow users to view
+    and possibly edit raw data within the interface in a spreadsheet style
+    view/control.
+

--- a/docs/source/gui/workspaces.rst
+++ b/docs/source/gui/workspaces.rst
@@ -13,7 +13,7 @@ application so that the user may easily navigate between multiple open
 workspaces.
 
 Each workspace defines its own custom widget(s) for interacting & manipulating
-data associated with its underlying controller (:class:`AbstractController`).
+data associated with its underlying controller (:class:`VirtualBaseController`).
 
 Workspaces may also contain sub-tabs, for example the :class:`DataSetTab`
 defines sub-tabs for viewing raw-data and selecting segments, and a tab for

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,10 @@ def shim_settings():
     settings = QSettings(QSettings.IniFormat, QSettings.UserScope, "DgS", "DGP")
     set_settings(settings)
     yield
-    os.unlink(settings.fileName())
+    try:
+        os.unlink(settings.fileName())
+    except FileNotFoundError:
+        pass
 
 
 def qt_msg_handler(type_, context, message: str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,7 +142,7 @@ def prj_ctrl(project):
 
 @pytest.fixture
 def flt_ctrl(prj_ctrl: AirborneProjectController):
-    return prj_ctrl.get_child(prj_ctrl.datamodel.flights[0].uid)
+    return prj_ctrl.get_child(prj_ctrl.entity.flights[0].uid)
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_controller_observers.py
+++ b/tests/test_controller_observers.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+import weakref
+
+import pytest
+
+from dgp.core import StateAction
+from dgp.core.models.flight import Flight
+from dgp.core.controllers.controller_interfaces import AbstractController
+
+
+@pytest.fixture
+def mock_model():
+    return Flight("TestFlt")
+
+
+class Observer:
+    def __init__(self, control: AbstractController):
+        control.register_observer(self, self.on_update, StateAction.UPDATE)
+        control.register_observer(self, self.on_delete, StateAction.DELETE)
+        self.control = weakref.ref(control)
+        self.updated = False
+        self.deleted = False
+
+    def on_update(self):
+        self.updated = True
+
+    def on_delete(self):
+        self.deleted = True
+
+
+# noinspection PyAbstractClass
+class ClonedControl(AbstractController):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.updated = False
+
+    def update(self):
+        self.updated = True
+
+
+def test_observer_notify(mock_model):
+    abc = AbstractController(mock_model, project=None)
+
+    assert not abc.is_active
+    observer = Observer(abc)
+    assert abc.is_active
+
+    assert not observer.updated
+    assert not observer.deleted
+
+    abc.update()
+    assert observer.updated
+    abc.delete()
+    assert observer.deleted
+
+
+def test_controller_clone(mock_model):
+    abc = AbstractController(mock_model, project=None)
+    assert not abc.is_clone
+
+    # AbstractController doesn't implement clone, so create our own adhoc clone
+    clone = ClonedControl(mock_model, None)
+    abc.register_clone(clone)
+
+    assert clone.is_clone
+    assert not clone.updated
+    abc.update()
+    assert clone.updated

--- a/tests/test_controller_observers.py
+++ b/tests/test_controller_observers.py
@@ -5,7 +5,7 @@ import pytest
 
 from dgp.core import StateAction
 from dgp.core.models.flight import Flight
-from dgp.core.controllers.controller_interfaces import AbstractController
+from dgp.core.controllers.controller_interfaces import VirtualBaseController
 
 
 @pytest.fixture
@@ -14,7 +14,7 @@ def mock_model():
 
 
 class Observer:
-    def __init__(self, control: AbstractController):
+    def __init__(self, control: VirtualBaseController):
         control.register_observer(self, self.on_update, StateAction.UPDATE)
         control.register_observer(self, self.on_delete, StateAction.DELETE)
         self.control = weakref.ref(control)
@@ -29,7 +29,7 @@ class Observer:
 
 
 # noinspection PyAbstractClass
-class ClonedControl(AbstractController):
+class ClonedControl(VirtualBaseController):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.updated = False
@@ -39,7 +39,7 @@ class ClonedControl(AbstractController):
 
 
 def test_observer_notify(mock_model):
-    abc = AbstractController(mock_model, project=None)
+    abc = VirtualBaseController(mock_model, project=None)
 
     assert not abc.is_active
     observer = Observer(abc)
@@ -55,10 +55,10 @@ def test_observer_notify(mock_model):
 
 
 def test_controller_clone(mock_model):
-    abc = AbstractController(mock_model, project=None)
+    abc = VirtualBaseController(mock_model, project=None)
     assert not abc.is_clone
 
-    # AbstractController doesn't implement clone, so create our own adhoc clone
+    # VirtualBaseController doesn't implement clone, so create our own adhoc clone
     clone = ClonedControl(mock_model, None)
     abc.register_clone(clone)
 

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -71,7 +71,7 @@ def test_gravimeter_controller(tmpdir):
     assert hash(meter_ctrl)
 
     meter_ctrl_clone = meter_ctrl.clone()
-    assert meter == meter_ctrl_clone.datamodel
+    assert meter == meter_ctrl_clone.entity
 
     assert "AT1A-Test" == meter_ctrl.data(Qt.DisplayRole)
     meter_ctrl.set_attr('name', "AT1A-New")
@@ -119,7 +119,7 @@ def test_flight_controller(project: AirborneProject):
     assert fc.get_child(dataset2.uid) is None
 
     fc.remove_child(dsc.uid, confirm=False)
-    assert 0 == len(fc.datamodel.datasets)
+    assert 0 == len(fc.entity.datasets)
 
 
 def test_FlightController_bindings(project: AirborneProject):
@@ -148,7 +148,7 @@ def test_airborne_project_controller(project):
     assert 2 == len(project.gravimeters)
 
     project_ctrl = AirborneProjectController(project)
-    assert project == project_ctrl.datamodel
+    assert project == project_ctrl.entity
     assert project_ctrl.path == project.path
     # Need a model to have a parent
     assert project_ctrl.parent_widget is None
@@ -179,7 +179,7 @@ def test_airborne_project_controller(project):
 
     fc2 = project_ctrl.get_child(flight2.uid)
     assert isinstance(fc2, FlightController)
-    assert flight2 == fc2.datamodel
+    assert flight2 == fc2.entity
 
     assert 5 == project_ctrl.flights.rowCount()
     project_ctrl.remove_child(flight2.uid, confirm=False)
@@ -196,34 +196,3 @@ def test_airborne_project_controller(project):
     jsons = project_ctrl.save(to_file=False)
     assert isinstance(jsons, str)
 
-
-def test_parent_child_activations(project: AirborneProject):
-    """Test child/parent interaction of DataSet Controller with
-    FlightController
-    """
-    prj_ctrl = AirborneProjectController(project)
-    flt_ctrl = prj_ctrl.get_child(project.flights[0].uid)
-    flt2 = Flight("Flt-2")
-    flt2_ctrl = prj_ctrl.add_child(flt2)
-
-    _ds_name = "DataSet-Test"
-    dataset = DataSet(name=_ds_name)
-    ds_ctrl = flt_ctrl.add_child(dataset)
-
-    assert prj_ctrl is flt_ctrl.get_parent()
-    assert flt_ctrl is ds_ctrl.get_parent()
-
-    assert prj_ctrl.can_activate
-    assert flt_ctrl.can_activate
-    assert ds_ctrl.can_activate
-
-    assert not prj_ctrl.is_active
-    assert not flt_ctrl.is_active
-
-    from dgp.core.types.enumerations import StateColor
-    assert StateColor.INACTIVE.value == prj_ctrl.background().color().name()
-    assert StateColor.INACTIVE.value == flt_ctrl.background().color().name()
-    assert StateColor.INACTIVE.value == ds_ctrl.background().color().name()
-
-    prj_ctrl.set_active(True)
-    assert StateColor.ACTIVE.value == prj_ctrl.background().color().name()

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -16,7 +16,7 @@ from dgp.core.models.dataset import DataSet, DataSegment
 from dgp.core.controllers.project_controllers import AirborneProjectController
 from dgp.core.models.project import AirborneProject
 from dgp.core.controllers.controller_mixins import AttributeProxy
-from dgp.core.controllers.controller_interfaces import IMeterController, AbstractController
+from dgp.core.controllers.controller_interfaces import IMeterController, VirtualBaseController
 from dgp.core.controllers.gravimeter_controller import GravimeterController
 from dgp.core.controllers.dataset_controller import (DataSetController,
                                                      DataSegmentController)
@@ -54,7 +54,7 @@ def test_gravimeter_controller(tmpdir):
     meter = Gravimeter('AT1A-Test')
     meter_ctrl = GravimeterController(meter, prj)
 
-    assert isinstance(meter_ctrl, AbstractController)
+    assert isinstance(meter_ctrl, VirtualBaseController)
     assert isinstance(meter_ctrl, IMeterController)
     assert isinstance(meter_ctrl, AttributeProxy)
 

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -16,7 +16,7 @@ from dgp.core.models.dataset import DataSet, DataSegment
 from dgp.core.controllers.project_controllers import AirborneProjectController
 from dgp.core.models.project import AirborneProject
 from dgp.core.controllers.controller_mixins import AttributeProxy
-from dgp.core.controllers.controller_interfaces import IChild, IMeterController, IParent
+from dgp.core.controllers.controller_interfaces import IMeterController, AbstractController
 from dgp.core.controllers.gravimeter_controller import GravimeterController
 from dgp.core.controllers.dataset_controller import (DataSetController,
                                                      DataSegmentController)
@@ -54,10 +54,9 @@ def test_gravimeter_controller(tmpdir):
     meter = Gravimeter('AT1A-Test')
     meter_ctrl = GravimeterController(meter)
 
-    assert isinstance(meter_ctrl, IChild)
+    assert isinstance(meter_ctrl, AbstractController)
     assert isinstance(meter_ctrl, IMeterController)
     assert isinstance(meter_ctrl, AttributeProxy)
-    assert not isinstance(meter_ctrl, IParent)
 
     assert meter == meter_ctrl.data(Qt.UserRole)
 
@@ -110,7 +109,7 @@ def test_flight_controller(project: AirborneProject):
     with pytest.raises(TypeError):
         fc.add_child({1: "invalid child"})
 
-    fc.set_parent(None)
+    # fc.set_parent(None)
 
     with pytest.raises(KeyError):
         fc.remove_child("Not a real child", confirm=False)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -52,7 +52,7 @@ def test_attribute_proxy(tmpdir):
 def test_gravimeter_controller(tmpdir):
     prj = AirborneProjectController(AirborneProject(name="TestPrj", path=Path(tmpdir)))
     meter = Gravimeter('AT1A-Test')
-    meter_ctrl = GravimeterController(meter)
+    meter_ctrl = GravimeterController(meter, prj)
 
     assert isinstance(meter_ctrl, AbstractController)
     assert isinstance(meter_ctrl, IMeterController)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -97,16 +97,11 @@ def test_flight_controller(project: AirborneProject):
     fc = prj_ctrl.add_child(flight)
     assert hash(fc)
     assert str(fc) == str(flight)
-    assert not fc.is_active
-    prj_ctrl.activate_child(fc.uid)
-    assert fc.is_active
     assert flight.uid == fc.uid
     assert flight.name == fc.data(Qt.DisplayRole)
 
     dsc = fc.get_child(dataset.uid)
-    fc.activate_child(dsc.uid)
     assert isinstance(dsc, DataSetController)
-    assert dsc == fc.active_child
 
     dataset2 = DataSet()
     dsc2 = fc.add_child(dataset2)
@@ -114,9 +109,6 @@ def test_flight_controller(project: AirborneProject):
 
     with pytest.raises(TypeError):
         fc.add_child({1: "invalid child"})
-
-    fc.activate_child(dsc.uid)
-    assert dsc == fc.active_child
 
     fc.set_parent(None)
 
@@ -129,7 +121,6 @@ def test_flight_controller(project: AirborneProject):
 
     fc.remove_child(dsc.uid, confirm=False)
     assert 0 == len(fc.datamodel.datasets)
-    assert fc.active_child is None
 
 
 def test_FlightController_bindings(project: AirborneProject):
@@ -143,13 +134,8 @@ def test_FlightController_bindings(project: AirborneProject):
         assert 2 == len(binding)
         assert hasattr(QMenu, binding[0])
 
-    assert prj_ctrl.active_child is None
-    fc0._activate_self()
-    assert fc0 == prj_ctrl.active_child
-    assert fc0.is_active
-
     assert fc0 == prj_ctrl.get_child(fc0.uid)
-    fc0._delete_self(confirm=False)
+    fc0._action_delete_self(confirm=False)
     assert prj_ctrl.get_child(fc0.uid) is None
 
 
@@ -190,12 +176,6 @@ def test_airborne_project_controller(project):
     assert isinstance(project_ctrl.meter_model, QStandardItemModel)
     assert isinstance(project_ctrl.flight_model, QStandardItemModel)
 
-    assert project_ctrl.active_child is None
-    project_ctrl.activate_child(fc.uid)
-    assert fc == project_ctrl.active_child
-    # with pytest.raises(ValueError):
-    #     project_ctrl.activate_child(mc)
-
     project_ctrl.add_child(flight2)
 
     fc2 = project_ctrl.get_child(flight2.uid)
@@ -216,178 +196,6 @@ def test_airborne_project_controller(project):
 
     jsons = project_ctrl.save(to_file=False)
     assert isinstance(jsons, str)
-
-
-def test_dataset_controller(tmpdir):
-    """Test DataSet controls
-    Load data from HDF5 Store
-    Behavior when incomplete (no grav or traj)
-    """
-    hdf = Path(tmpdir).joinpath('test.hdf5')
-    prj = AirborneProject(name="TestPrj", path=Path(tmpdir))
-    flt = Flight("TestFlt")
-    grav_file = DataFile(DataType.GRAVITY, datetime.now(), Path(tmpdir).joinpath('gravity.dat'))
-    traj_file = DataFile(DataType.TRAJECTORY, datetime.now(), Path(tmpdir).joinpath('trajectory.txt'))
-    ds = DataSet(grav_file, traj_file)
-    seg0 = DataSegment(OID(), Timestamp.now(), Timestamp.now() + Timedelta(minutes=30), 0)
-    ds.segments.append(seg0)
-
-    flt.datasets.append(ds)
-    prj.add_child(flt)
-
-    prj_ctrl = AirborneProjectController(prj)
-    fc0 = prj_ctrl.get_child(flt.uid)
-    dsc: DataSetController = fc0.get_child(ds.uid)
-    assert 1 == dsc._segments.rowCount()
-
-    assert isinstance(dsc, DataSetController)
-    assert fc0 == dsc.get_parent()
-    assert grav_file == dsc.get_datafile(grav_file.group).datamodel
-    assert traj_file == dsc.get_datafile(traj_file.group).datamodel
-
-    grav1_file = DataFile(DataType.GRAVITY, datetime.now(), Path(tmpdir).joinpath('gravity2.dat'))
-    dsc.add_datafile(grav1_file)
-    assert grav1_file == dsc.get_datafile(grav1_file.group).datamodel
-
-    traj1_file = DataFile(DataType.TRAJECTORY, datetime.now(), Path(tmpdir).joinpath('traj2.txt'))
-    dsc.add_datafile(traj1_file)
-    assert traj1_file == dsc.get_datafile(traj1_file.group).datamodel
-
-    invl_file = DataFile('marine', datetime.now(), Path(tmpdir))
-    with pytest.raises(TypeError):
-        dsc.add_datafile(invl_file)
-
-    with pytest.raises(KeyError):
-        dsc.get_datafile('marine')
-
-    # Test Data Segment Features
-    _seg_oid = OID(tag="seg1")
-    _seg1_start = Timestamp.now()
-    _seg1_stop = Timestamp.now() + Timedelta(hours=1)
-    seg1_ctrl = dsc.add_segment(_seg_oid, _seg1_start, _seg1_stop, label="seg1")
-    seg1: DataSegment = seg1_ctrl.datamodel
-    assert _seg1_start == seg1.start
-    assert _seg1_stop == seg1.stop
-    assert "seg1" == seg1.label
-
-    assert seg1_ctrl == dsc.get_segment(_seg_oid)
-    assert isinstance(seg1_ctrl, DataSegmentController)
-    assert "seg1" == seg1_ctrl.get_attr('label')
-    assert _seg_oid == seg1_ctrl.uid
-
-    assert 2 == len(ds.segments)
-    assert ds.segments[1] == seg1_ctrl.datamodel
-    assert ds.segments[1] == seg1_ctrl.data(Qt.UserRole)
-
-    # Segment updates
-    _new_start = Timestamp.now() + Timedelta(hours=2)
-    _new_stop = Timestamp.now() + Timedelta(hours=3)
-    dsc.update_segment(seg1.uid, _new_start, _new_stop)
-    assert _new_start == seg1.start
-    assert _new_stop == seg1.stop
-    assert "seg1" == seg1.label
-
-    dsc.update_segment(seg1.uid, label="seg1label")
-    assert "seg1label" == seg1.label
-
-    invalid_uid = OID()
-    assert dsc.get_segment(invalid_uid) is None
-    with pytest.raises(KeyError):
-        dsc.remove_segment(invalid_uid)
-    with pytest.raises(KeyError):
-        dsc.update_segment(invalid_uid, label="RaiseError")
-
-    assert 2 == len(ds.segments)
-    dsc.remove_segment(seg1.uid)
-    assert 1 == len(ds.segments)
-    assert 1 == dsc._segments.rowCount()
-
-
-def test_dataset_datafiles(project: AirborneProject):
-    prj_ctrl = AirborneProjectController(project)
-    flt_ctrl = prj_ctrl.get_child(project.flights[0].uid)
-    ds_ctrl = flt_ctrl.get_child(flt_ctrl.datamodel.datasets[0].uid)
-
-    grav_file = ds_ctrl.datamodel.gravity
-    grav_file_ctrl = ds_ctrl.get_datafile(DataType.GRAVITY)
-    gps_file = ds_ctrl.datamodel.trajectory
-    gps_file_ctrl = ds_ctrl.get_datafile(DataType.TRAJECTORY)
-
-    assert grav_file.uid == grav_file_ctrl.uid
-    assert ds_ctrl == grav_file_ctrl.dataset
-    assert grav_file.group == grav_file_ctrl.group
-
-    assert gps_file.uid == gps_file_ctrl.uid
-    assert ds_ctrl == gps_file_ctrl.dataset
-    assert gps_file.group == gps_file_ctrl.group
-
-
-def test_dataset_reparenting(project: AirborneProject):
-    # Test reassignment of DataSet to another Flight
-    # Note: FlightController automatically adds empty DataSet if Flight has None
-    prj_ctrl = AirborneProjectController(project)
-    flt1ctrl = prj_ctrl.get_child(project.flights[0].uid)
-    flt2ctrl = prj_ctrl.get_child(project.flights[1].uid)
-    dsctrl = flt1ctrl.get_child(flt1ctrl.datamodel.datasets[0].uid)
-    assert isinstance(dsctrl, DataSetController)
-
-    assert 1 == len(flt1ctrl.datamodel.datasets)
-    assert 1 == flt1ctrl.rowCount()
-
-    assert 1 == len(flt2ctrl.datamodel.datasets)
-    assert 1 == flt2ctrl.rowCount()
-
-    assert flt1ctrl == dsctrl.get_parent()
-
-    dsctrl.set_parent(flt2ctrl)
-    assert 2 == flt2ctrl.rowCount()
-    assert 0 == flt1ctrl.rowCount()
-    assert flt2ctrl == dsctrl.get_parent()
-
-    # DataSetController is recreated when added to new flight.
-    assert not dsctrl == flt2ctrl.get_child(dsctrl.uid)
-    assert flt1ctrl.get_child(dsctrl.uid) is None
-
-
-def test_dataset_data_api(project: AirborneProject, hdf5file, gravdata, gpsdata):
-    prj_ctrl = AirborneProjectController(project)
-    flt_ctrl = prj_ctrl.get_child(project.flights[0].uid)
-
-    gravfile = DataFile(DataType.GRAVITY, datetime.now(),
-                        Path('tests/sample_gravity.csv'))
-    gpsfile = DataFile(DataType.TRAJECTORY, datetime.now(),
-                       Path('tests/sample_trajectory.txt'), column_format='hms')
-
-    dataset = DataSet(gravfile, gpsfile)
-
-    HDF5Manager.save_data(gravdata, gravfile, hdf5file)
-    HDF5Manager.save_data(gpsdata, gpsfile, hdf5file)
-
-    dataset_ctrl = DataSetController(dataset, flt_ctrl)
-
-    gravity_frame = HDF5Manager.load_data(gravfile, hdf5file)
-    assert gravity_frame.equals(dataset_ctrl.gravity)
-
-    trajectory_frame = HDF5Manager.load_data(gpsfile, hdf5file)
-    assert trajectory_frame.equals(dataset_ctrl.trajectory)
-
-    assert dataset_ctrl.dataframe() is not None
-    expected: DataFrame = pd.concat([gravdata, gpsdata], axis=1, sort=True)
-    expected_cols = [col for col in expected]
-
-    assert expected.equals(dataset_ctrl.dataframe())
-    assert set(expected_cols) == set(dataset_ctrl.columns)
-
-    series_model = dataset_ctrl.series_model
-    assert isinstance(series_model, QStandardItemModel)
-    assert len(expected_cols) == series_model.rowCount()
-
-    for i in range(series_model.rowCount()):
-        item: QStandardItem = series_model.item(i, 0)
-        col = item.data(Qt.DisplayRole)
-        series = item.data(Qt.UserRole)
-
-        assert expected[col].equals(series)
 
 
 def test_parent_child_activations(project: AirborneProject):
@@ -420,20 +228,3 @@ def test_parent_child_activations(project: AirborneProject):
 
     prj_ctrl.set_active(True)
     assert StateColor.ACTIVE.value == prj_ctrl.background().color().name()
-    flt_ctrl.set_active(True)
-
-    # Test exclusive/non-exclusive child activation
-    assert flt_ctrl is prj_ctrl.active_child
-    prj_ctrl.activate_child(flt2_ctrl.uid, exclusive=False)
-    assert flt_ctrl.is_active
-    assert flt2_ctrl.is_active
-
-    prj_ctrl.activate_child(flt2_ctrl.uid, exclusive=True)
-    assert flt2_ctrl.is_active
-    assert not flt_ctrl.is_active
-
-
-
-
-
-

--- a/tests/test_dataset_controller.py
+++ b/tests/test_dataset_controller.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import pandas as pd
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QStandardItemModel, QStandardItem
+from pandas import Timestamp, Timedelta, DataFrame
+
+from dgp.core.hdf5_manager import HDF5Manager
+from dgp.core import OID, DataType
+from dgp.core.models.datafile import DataFile
+from dgp.core.models.dataset import DataSet, DataSegment
+from dgp.core.models.flight import Flight
+from dgp.core.models.project import AirborneProject
+from dgp.core.controllers.project_controllers import AirborneProjectController
+from dgp.core.controllers.dataset_controller import DataSetController, DataSegmentController
+
+
+def test_dataset_controller(tmpdir):
+    """Test DataSet controls
+    Load data from HDF5 Store
+    Behavior when incomplete (no grav or traj)
+    """
+    hdf = Path(tmpdir).joinpath('test.hdf5')
+    prj = AirborneProject(name="TestPrj", path=Path(tmpdir))
+    flt = Flight("TestFlt")
+    grav_file = DataFile(DataType.GRAVITY, datetime.now(), Path(tmpdir).joinpath('gravity.dat'))
+    traj_file = DataFile(DataType.TRAJECTORY, datetime.now(), Path(tmpdir).joinpath('trajectory.txt'))
+    ds = DataSet(grav_file, traj_file)
+    seg0 = DataSegment(OID(), Timestamp.now(), Timestamp.now() + Timedelta(minutes=30), 0)
+    ds.segments.append(seg0)
+
+    flt.datasets.append(ds)
+    prj.add_child(flt)
+
+    prj_ctrl = AirborneProjectController(prj)
+    fc0 = prj_ctrl.get_child(flt.uid)
+    dsc: DataSetController = fc0.get_child(ds.uid)
+    assert 1 == dsc._segments.rowCount()
+
+    assert isinstance(dsc, DataSetController)
+    assert fc0 == dsc.get_parent()
+    assert grav_file == dsc.get_datafile(grav_file.group).datamodel
+    assert traj_file == dsc.get_datafile(traj_file.group).datamodel
+
+    grav1_file = DataFile(DataType.GRAVITY, datetime.now(), Path(tmpdir).joinpath('gravity2.dat'))
+    dsc.add_datafile(grav1_file)
+    assert grav1_file == dsc.get_datafile(grav1_file.group).datamodel
+
+    traj1_file = DataFile(DataType.TRAJECTORY, datetime.now(), Path(tmpdir).joinpath('traj2.txt'))
+    dsc.add_datafile(traj1_file)
+    assert traj1_file == dsc.get_datafile(traj1_file.group).datamodel
+
+    invl_file = DataFile('marine', datetime.now(), Path(tmpdir))
+    with pytest.raises(TypeError):
+        dsc.add_datafile(invl_file)
+
+    with pytest.raises(KeyError):
+        dsc.get_datafile('marine')
+
+    # Test Data Segment Features
+    _seg_oid = OID(tag="seg1")
+    _seg1_start = Timestamp.now()
+    _seg1_stop = Timestamp.now() + Timedelta(hours=1)
+    seg1_ctrl = dsc.add_segment(_seg_oid, _seg1_start, _seg1_stop, label="seg1")
+    seg1: DataSegment = seg1_ctrl.datamodel
+    assert _seg1_start == seg1.start
+    assert _seg1_stop == seg1.stop
+    assert "seg1" == seg1.label
+
+    assert seg1_ctrl == dsc.get_segment(_seg_oid)
+    assert isinstance(seg1_ctrl, DataSegmentController)
+    assert "seg1" == seg1_ctrl.get_attr('label')
+    assert _seg_oid == seg1_ctrl.uid
+
+    assert 2 == len(ds.segments)
+    assert ds.segments[1] == seg1_ctrl.datamodel
+    assert ds.segments[1] == seg1_ctrl.data(Qt.UserRole)
+
+    # Segment updates
+    _new_start = Timestamp.now() + Timedelta(hours=2)
+    _new_stop = Timestamp.now() + Timedelta(hours=3)
+    dsc.update_segment(seg1.uid, _new_start, _new_stop)
+    assert _new_start == seg1.start
+    assert _new_stop == seg1.stop
+    assert "seg1" == seg1.label
+
+    dsc.update_segment(seg1.uid, label="seg1label")
+    assert "seg1label" == seg1.label
+
+    invalid_uid = OID()
+    assert dsc.get_segment(invalid_uid) is None
+    with pytest.raises(KeyError):
+        dsc.remove_segment(invalid_uid)
+    with pytest.raises(KeyError):
+        dsc.update_segment(invalid_uid, label="RaiseError")
+
+    assert 2 == len(ds.segments)
+    dsc.remove_segment(seg1.uid)
+    assert 1 == len(ds.segments)
+    assert 1 == dsc._segments.rowCount()
+
+
+def test_dataset_datafiles(project: AirborneProject):
+    prj_ctrl = AirborneProjectController(project)
+    flt_ctrl = prj_ctrl.get_child(project.flights[0].uid)
+    ds_ctrl = flt_ctrl.get_child(flt_ctrl.datamodel.datasets[0].uid)
+
+    grav_file = ds_ctrl.datamodel.gravity
+    grav_file_ctrl = ds_ctrl.get_datafile(DataType.GRAVITY)
+    gps_file = ds_ctrl.datamodel.trajectory
+    gps_file_ctrl = ds_ctrl.get_datafile(DataType.TRAJECTORY)
+
+    assert grav_file.uid == grav_file_ctrl.uid
+    assert ds_ctrl == grav_file_ctrl.dataset
+    assert grav_file.group == grav_file_ctrl.group
+
+    assert gps_file.uid == gps_file_ctrl.uid
+    assert ds_ctrl == gps_file_ctrl.dataset
+    assert gps_file.group == gps_file_ctrl.group
+
+
+# def test_dataset_reparenting(project: AirborneProject):
+#     # Test reassignment of DataSet to another Flight
+#     # Note: FlightController automatically adds empty DataSet if Flight has None
+#     prj_ctrl = AirborneProjectController(project)
+#     flt1ctrl = prj_ctrl.get_child(project.flights[0].uid)
+#     flt2ctrl = prj_ctrl.get_child(project.flights[1].uid)
+#     dsctrl = flt1ctrl.get_child(flt1ctrl.datamodel.datasets[0].uid)
+#     assert isinstance(dsctrl, DataSetController)
+#
+#     assert 1 == len(flt1ctrl.datamodel.datasets)
+#     assert 1 == flt1ctrl.rowCount()
+#
+#     assert 1 == len(flt2ctrl.datamodel.datasets)
+#     assert 1 == flt2ctrl.rowCount()
+#
+#     assert flt1ctrl == dsctrl.get_parent()
+#
+#     dsctrl.set_parent(flt2ctrl)
+#     assert 2 == flt2ctrl.rowCount()
+#     assert 0 == flt1ctrl.rowCount()
+#     assert flt2ctrl == dsctrl.get_parent()
+#
+#     # DataSetController is recreated when added to new flight.
+#     assert not dsctrl == flt2ctrl.get_child(dsctrl.uid)
+#     assert flt1ctrl.get_child(dsctrl.uid) is None
+
+
+def test_dataset_data_api(project: AirborneProject, hdf5file, gravdata, gpsdata):
+    prj_ctrl = AirborneProjectController(project)
+    flt_ctrl = prj_ctrl.get_child(project.flights[0].uid)
+
+    gravfile = DataFile(DataType.GRAVITY, datetime.now(),
+                        Path('tests/sample_gravity.csv'))
+    gpsfile = DataFile(DataType.TRAJECTORY, datetime.now(),
+                       Path('tests/sample_trajectory.txt'), column_format='hms')
+
+    dataset = DataSet(gravfile, gpsfile)
+
+    HDF5Manager.save_data(gravdata, gravfile, hdf5file)
+    HDF5Manager.save_data(gpsdata, gpsfile, hdf5file)
+
+    dataset_ctrl = DataSetController(dataset, flt_ctrl)
+
+    gravity_frame = HDF5Manager.load_data(gravfile, hdf5file)
+    assert gravity_frame.equals(dataset_ctrl.gravity)
+
+    trajectory_frame = HDF5Manager.load_data(gpsfile, hdf5file)
+    assert trajectory_frame.equals(dataset_ctrl.trajectory)
+
+    assert dataset_ctrl.dataframe() is not None
+    expected: DataFrame = pd.concat([gravdata, gpsdata], axis=1, sort=True)
+    expected_cols = [col for col in expected]
+
+    assert expected.equals(dataset_ctrl.dataframe())
+    assert set(expected_cols) == set(dataset_ctrl.columns)
+
+    series_model = dataset_ctrl.series_model
+    assert isinstance(series_model, QStandardItemModel)
+    assert len(expected_cols) == series_model.rowCount()
+
+    for i in range(series_model.rowCount()):
+        item: QStandardItem = series_model.item(i, 0)
+        col = item.data(Qt.DisplayRole)
+        series = item.data(Qt.UserRole)
+
+        assert expected[col].equals(series)
+

--- a/tests/test_dataset_controller.py
+++ b/tests/test_dataset_controller.py
@@ -124,33 +124,6 @@ def test_dataset_datafiles(project: AirborneProject):
     assert gps_file.group == gps_file_ctrl.group
 
 
-# def test_dataset_reparenting(project: AirborneProject):
-#     # Test reassignment of DataSet to another Flight
-#     # Note: FlightController automatically adds empty DataSet if Flight has None
-#     prj_ctrl = AirborneProjectController(project)
-#     flt1ctrl = prj_ctrl.get_child(project.flights[0].uid)
-#     flt2ctrl = prj_ctrl.get_child(project.flights[1].uid)
-#     dsctrl = flt1ctrl.get_child(flt1ctrl.datamodel.datasets[0].uid)
-#     assert isinstance(dsctrl, DataSetController)
-#
-#     assert 1 == len(flt1ctrl.datamodel.datasets)
-#     assert 1 == flt1ctrl.rowCount()
-#
-#     assert 1 == len(flt2ctrl.datamodel.datasets)
-#     assert 1 == flt2ctrl.rowCount()
-#
-#     assert flt1ctrl == dsctrl.get_parent()
-#
-#     dsctrl.set_parent(flt2ctrl)
-#     assert 2 == flt2ctrl.rowCount()
-#     assert 0 == flt1ctrl.rowCount()
-#     assert flt2ctrl == dsctrl.get_parent()
-#
-#     # DataSetController is recreated when added to new flight.
-#     assert not dsctrl == flt2ctrl.get_child(dsctrl.uid)
-#     assert flt1ctrl.get_child(dsctrl.uid) is None
-
-
 def test_dataset_data_api(project: AirborneProject, hdf5file, gravdata, gpsdata):
     prj_ctrl = AirborneProjectController(project)
     flt_ctrl = prj_ctrl.get_child(project.flights[0].uid)
@@ -165,7 +138,7 @@ def test_dataset_data_api(project: AirborneProject, hdf5file, gravdata, gpsdata)
     HDF5Manager.save_data(gravdata, gravfile, hdf5file)
     HDF5Manager.save_data(gpsdata, gpsfile, hdf5file)
 
-    dataset_ctrl = DataSetController(dataset, flt_ctrl, project=prj_ctrl)
+    dataset_ctrl = DataSetController(dataset, prj_ctrl, flt_ctrl)
 
     gravity_frame = HDF5Manager.load_data(gravfile, hdf5file)
     assert gravity_frame.equals(dataset_ctrl.gravity)

--- a/tests/test_gui_main.py
+++ b/tests/test_gui_main.py
@@ -60,33 +60,6 @@ def test_MainWindow_tab_open_requested(project, window):
     assert 1 == window.workspace.count()
 
 
-def test_MainWindow_tab_close_requested(project, window):
-    tab_close_spy = QSignalSpy(window.model.tabCloseRequested)
-    assert 0 == len(tab_close_spy)
-    assert 0 == window.workspace.count()
-
-    flt_ctrl = window.model.active_project.get_child(project.flights[0].uid)
-
-    window.model.item_activated(flt_ctrl.index())
-    assert 1 == window.workspace.count()
-
-    window.model.close_flight(flt_ctrl)
-    assert 1 == len(tab_close_spy)
-    assert flt_ctrl.uid == tab_close_spy[0][0]
-    assert window.workspace.get_tab(flt_ctrl.uid) is None
-
-    window.model.item_activated(flt_ctrl.index())
-    assert 1 == window.workspace.count()
-    assert window.workspace.get_tab(flt_ctrl.uid) is not None
-
-    window.workspace.tabCloseRequested.emit(0)
-    assert 0 == window.workspace.count()
-
-    assert 1 == len(tab_close_spy)
-    window.model.close_flight(flt_ctrl)
-    assert 2 == len(tab_close_spy)
-
-
 def test_MainWindow_project_mutated(window: MainWindow):
     assert not window.isWindowModified()
     window.model.projectMutated.emit()

--- a/tests/test_project_treemodel.py
+++ b/tests/test_project_treemodel.py
@@ -34,16 +34,3 @@ def test_ProjectTreeModel_multiple_projects(project: AirborneProject,
     assert prj_ctrl in model.projects
     assert prj_ctrl2 in model.projects
 
-
-def test_ProjectTreeModel_item_activated(prj_ctrl: AirborneProjectController,
-                                         flt_ctrl: FlightController):
-    model = ProjectTreeModel(prj_ctrl)
-    assert prj_ctrl is model.active_project
-    tabOpen_spy = QSignalSpy(model.tabOpenRequested)
-
-    fc1_index = model.index(flt_ctrl.row(), 0,
-                            parent=model.index(prj_ctrl.flights.row(), 0,
-                                               parent=model.index(prj_ctrl.row(), 0)))
-    assert not flt_ctrl.is_active
-    model.item_activated(fc1_index)
-    assert 1 == len(tabOpen_spy)


### PR DESCRIPTION
This branch implements an *observer/subscriber* pattern among the core controllers and consumers of them in the GUI module.

---

Rationale
----------

The reasoning behind this is that the controllers (which themselves encapsulate primitive 'data'/model classes comprising the project structure), are used within the GUI to construct various interfaces for the user to interact with and mutate data in the project; particularly in the gui/workspace package at the moment. 

The reason for implementing such a observer system is that mutations and actions can be initiated by the user from multiple contexts, e.g. the user can create Data Set segments from within the Data Set workspace tab (clicking on the graphical plot), which creates a new child entry in the project tree. 
These segment children can be mutated from outside of the workspace by a context menu in the project navigator. When a segment is mutated/deleted this action needs to be propagated back to the plot so that it can update/remove the visual representation.

The other primary case for this feature is for propagating attribute updates and/or state-changes from controllers to UI (e.g. workspace) subscribers. For example when a project is closed, or a flight is deleted from the project, all workspaces which reference those objects (or their children) must be disposed.

This feature branch also enhances the cloning interface for controllers which should deal with some minor UI bugs encountered in the past. Clones of a base controller similarly subscribe to updates in order to update their representation when the base object is mutated. Issues would often appear previously where the base object's friendly-name was changed, but this change was not propagated to any of its clones, resulting in an inconsistent visual state.

Other Changes/Enhancements
----------------------------------

Some other changes were made in support of, or ancillary to the major observer/subscriber model implemented:

- Controller interfaces have been renamed/enhanced. IBaseController renamed to VirtualBaseController. The VirtualBaseController implements some common methods for inheritors, and does away with the need for the IParent/IChild interfaces.
- Documentation added for GUI Workspaces module/packages
- Refactor controllers to carry a reference to their base (owning) project, this simplifies API calls for deeper nested controllers/models which occasionally need access to a project attribute (e.g. getting the projects HDF5 store path to load data)